### PR TITLE
feat: disable iOS backup 

### DIFF
--- a/ios/RNCAsyncStorage.m
+++ b/ios/RNCAsyncStorage.m
@@ -34,7 +34,7 @@ static NSDictionary *RCTErrorForKey(NSString *key)
   }
 }
 
-static BOOL setBackupEnabled(NSString* path, BOOL isEnabled)
+static BOOL RCTAsyncStorageSetBackupEnabled(NSString* path, BOOL isEnabled)
 {
     NSFileManager *fileManager = [[NSFileManager alloc] init];
     
@@ -42,17 +42,16 @@ static BOOL setBackupEnabled(NSString* path, BOOL isEnabled)
     BOOL exists = [fileManager fileExistsAtPath:path isDirectory:&isDir];
     BOOL success = false;
     
-    if(isDir && exists) {
+    if (isDir && exists) {
         NSURL* pathUrl = [NSURL fileURLWithPath:path];
         NSError *error = nil;
-        success = [pathUrl setResourceValue:[NSNumber numberWithBool:isEnabled] forKey:NSURLIsExcludedFromBackupKey error: &error];
+        success = [pathUrl setResourceValue:@(isEnabled) forKey:NSURLIsExcludedFromBackupKey error:&error];
 
-        if(!success){
+        if (!success) {
             NSLog(@"Could not exclude AsyncStorage dir from backup %@", error);
         }
     }
     return success;
-
 }
 
 static void RCTAppendError(NSDictionary *error, NSMutableArray<NSDictionary *> **errors)
@@ -342,8 +341,8 @@ static void RCTStorageDirectoryMigrationCheck(NSString *fromStorageDirectory, NS
   // Then migrate what's in "Documents/.../RCTAsyncLocalStorage_V1" to "Application Support/[bundleID]/RCTAsyncLocalStorage_V1"
   RCTStorageDirectoryMigrationCheck(RCTCreateStorageDirectoryPath_deprecated(RCTStorageDirectory), RCTCreateStorageDirectoryPath(RCTStorageDirectory), NO);
     
-  // exclude from backup
-  //setBackupEnabled(RCTCreateStorageDirectoryPath(RCTStorageDirectory), false);
+  // todo: decide how to read the flag
+  //RCTAsyncStorageSetBackupEnabled(RCTCreateStorageDirectoryPath(RCTStorageDirectory), false);
   
   return self;
 }

--- a/ios/RNCAsyncStorage.m
+++ b/ios/RNCAsyncStorage.m
@@ -34,6 +34,27 @@ static NSDictionary *RCTErrorForKey(NSString *key)
   }
 }
 
+static BOOL setBackupEnabled(NSString* path, BOOL isEnabled)
+{
+    NSFileManager *fileManager = [[NSFileManager alloc] init];
+    
+    BOOL isDir;
+    BOOL exists = [fileManager fileExistsAtPath:path isDirectory:&isDir];
+    BOOL success = false;
+    
+    if(isDir && exists) {
+        NSURL* pathUrl = [NSURL fileURLWithPath:path];
+        NSError *error = nil;
+        success = [pathUrl setResourceValue:[NSNumber numberWithBool:isEnabled] forKey:NSURLIsExcludedFromBackupKey error: &error];
+
+        if(!success){
+            NSLog(@"Could not exclude AsyncStorage dir from backup %@", error);
+        }
+    }
+    return success;
+
+}
+
 static void RCTAppendError(NSDictionary *error, NSMutableArray<NSDictionary *> **errors)
 {
   if (error && errors) {
@@ -320,7 +341,10 @@ static void RCTStorageDirectoryMigrationCheck(NSString *fromStorageDirectory, NS
   
   // Then migrate what's in "Documents/.../RCTAsyncLocalStorage_V1" to "Application Support/[bundleID]/RCTAsyncLocalStorage_V1"
   RCTStorageDirectoryMigrationCheck(RCTCreateStorageDirectoryPath_deprecated(RCTStorageDirectory), RCTCreateStorageDirectoryPath(RCTStorageDirectory), NO);
-
+    
+  // exclude from backup
+  //setBackupEnabled(RCTCreateStorageDirectoryPath(RCTStorageDirectory), false);
+  
   return self;
 }
 


### PR DESCRIPTION
Summary:
---------

Moved from [other repo](https://github.com/react-native-community/async-storage/pull/455)

Feature to disable (enabled by default) iCloud backup for `AsyncStorage` files.

To Do:
----------
- [ ] Feature flag toggle


Test Plan:
----------

<!-- Help us test your work (**REQUIRED**). If you changed the code, please provide us with instructions of how we can try it out ourselves, so we can confirm it's working. You can also post screenshots/gifts.  -->