### PR TITLE
fix(iOS): Unable to find a specification for `React-Core`

### DIFF
--- a/RNCAsyncStorage.podspec
+++ b/RNCAsyncStorage.podspec
@@ -12,8 +12,8 @@ Pod::Spec.new do |s|
   s.homepage     = package['homepage']
   s.platforms    = { :ios => "9.0", :tvos => "9.2", :osx => "10.14" }
 
-  s.source       = { :git => "https://github.com/react-native-community/react-native-async-storage.git", :tag => "v#{s.version}" }
+  s.source       = { :git => "https://github.com/react-native-async-storage/async-storage.git", :tag => "v#{s.version}" }
   s.source_files  = "ios/**/*.{h,m}"
 
-  s.dependency 'React-Core'
+  s.dependency 'React'
 end


### PR DESCRIPTION
Summary:
---------

AsyncStorage fails to build with RN 0.63:

```
[!] Unable to find a specification for `React-Core` depended upon by `RNCAsyncStorage`
```

Resolves #457.

Test Plan:
----------

CI build should pass.