### PR TITLE
fix(Android): Find react-native using node module resolution

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,3 +1,22 @@
+import java.nio.file.Paths
+
+def resolveModulePath(packageName) {
+    def basePath = rootDir.toPath().normalize()
+
+    // Node's module resolution algorithm searches up to the root directory,
+    // after which the base path will be null
+    while (basePath) {
+        def candidatePath = Paths.get(basePath.toString(), 'node_modules', packageName)
+        if (candidatePath.toFile().exists()) {
+            return candidatePath.toString()
+        }
+
+        basePath = basePath.getParent()
+    }
+
+    return null
+}
+
 def safeExtGet(prop, fallback) {
     rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
 }
@@ -53,7 +72,7 @@ repositories {
     mavenLocal()
     maven {
         // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
-        url "$rootDir/../node_modules/react-native/android"
+        url "${resolveModulePath("react-native")}/android"
     }
     google()
     jcenter()


### PR DESCRIPTION
Summary:
---------

AsyncStorage assumes that it is installed in `node_modules` in the parent folder. This may not always be the case.

Test Plan:
----------

Android CI should pass.