### PR TITLE
Fix ios build for xcode 12 + use_frameworks!

### DIFF
--- a/RNCAsyncStorage.podspec
+++ b/RNCAsyncStorage.podspec
@@ -15,5 +15,5 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://github.com/react-native-async-storage/async-storage.git", :tag => "v#{s.version}" }
   s.source_files  = "ios/**/*.{h,m}"
 
-  s.dependency 'React'
+  s.dependency 'React-Core'
 end


### PR DESCRIPTION
## Summary

Fix for issue described in https://github.com/react-native-async-storage/async-storage/issues/509

## Test Plan

Build a new RN project referencing PR branch
```
npx react-native init RNAsyncStorage && cd RNAsyncStorage
yarn add https://github.com/stu-dev/async-storage#fix/xcode-12-use-frameworks
```
- Add `use_frameworks!` to Podfile (also disable flipper)
```
npx pod-install
yarn ios
```
