### PR TITLE
Fix mergeItem API documentation

### DIFF
--- a/website/docs/API.md
+++ b/website/docs/API.md
@@ -172,6 +172,7 @@ mergeUsers = async () => {
     // {
     //   name: 'Sarah',
     //   age: 21,
+    //   hobby: 'cars',
     //   traits: {
     //     eyes: 'green',
     //     hair: 'black'


### PR DESCRIPTION
## FIX mergeItem method API documentation

Missed property `hobby` on console.log after merging items