### PR TITLE
feat(android): Use Room library for persistent storage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -151,6 +151,26 @@ jobs:
           name: Flow check
           command: yarn test:flow
 
+  "Test: Android unit":
+    <<: *android_defaults
+    steps:
+      - *addWorkspace
+      - restore-cache: *cache_restore_yarn
+      - run:
+          name: Installing Yarn dependencies
+          command: yarn --pure-lockfile --non-interactive --cache-folder ~/.cache/yarn
+      - save-cache: *cache_save_yarn
+      - restore-cache: *cache_restore_gradle
+      - run:
+          name: Downloading Gradle dependencies
+          working_directory: example/android
+          command: ./gradlew --max-workers 2 fetchDependencies
+      - save-cache: *cache_save_gradle
+      - run:
+          name: Next storage tests
+          working_directory: example/android
+          command: ./gradlew react-native-async-storage_async-storage:test
+
   "Test: iOS e2e":
     <<: *macos_defaults
     steps:
@@ -188,21 +208,22 @@ jobs:
           name: Run e2e tests
           command: yarn test:e2e:ios
 
+
   "Build: Android release apk":
     <<: *android_defaults
     steps:
       - *addWorkspace
-      - restore-cache: *cache_restore_yarn
-      - run:
-          name: Installing Yarn dependencies
-          command: yarn --pure-lockfile --non-interactive --cache-folder ~/.cache/yarn
-      - save-cache: *cache_save_yarn
-      - restore-cache: *cache_restore_gradle
-      - run:
-          name: Downloading Gradle dependencies
-          working_directory: example/android
-          command: ./gradlew --max-workers 2 fetchDependencies
-      - save-cache: *cache_save_gradle
+#      - restore-cache: *cache_restore_yarn
+#      - run:
+#          name: Installing Yarn dependencies
+#          command: yarn --pure-lockfile --non-interactive --cache-folder ~/.cache/yarn
+#      - save-cache: *cache_save_yarn
+#      - restore-cache: *cache_restore_gradle
+#      - run:
+#          name: Downloading Gradle dependencies
+#          working_directory: example/android
+#          command: ./gradlew --max-workers 2 fetchDependencies
+#      - save-cache: *cache_save_gradle
       - run:
           name: Bundle JS
           command: yarn bundle:android --dev false
@@ -306,6 +327,9 @@ workflows:
       - "Test: flow":
           requires:
             - "Setup environment"
+      - "Test: Android unit":
+          requires:
+            - "Setup environment"
       - "Test: iOS e2e":
           requires:
             - "Test: lint"
@@ -314,6 +338,7 @@ workflows:
           requires:
             - "Test: lint"
             - "Test: flow"
+            - "Test: Android unit"
       - "Test: Android e2e":
           requires:
             - "Build: Android release apk"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,7 @@ cache keys:
   brew ios: &key_brew_ios cache-brew-ios-v4-{{ arch }}
   brew android: &key_brew_android cache-brew-android-v4-{{ arch }}
   yarn: &key_yarn cache-yarn-{{ checksum "package.json" }}-{{ arch }}
-  gradle: &key_gradle cache-gradle-{{ checksum "example/android/gradle/wrapper/gradle-wrapper.properties" }}-{{ checksum "package.json" }}-{{ arch }}
+  gradle: &key_gradle cache-gradle-v1-{{ checksum "example/android/gradle/wrapper/gradle-wrapper.properties" }}-{{ checksum "package.json" }}-{{ arch }}
   pods: &key_pods cache-pods-v1-{{ checksum "example/ios/Podfile" }}-{{ checksum "package.json" }}-{{ arch }}
 
 cache:
@@ -216,8 +216,12 @@ jobs:
           name: Bundle JS
           command: yarn bundle:android --dev false
       - run:
-          name: Build APK
+          name: Build APKs
           command: yarn build:e2e:android
+      - run:
+          name: Build APK with Next storage
+          working_directory: example/android
+          command: ./gradlew assembleNext --max-workers 2
       - persist_to_workspace:
           root: ~/async_storage
           paths:
@@ -292,6 +296,9 @@ jobs:
       - run:
           name: Run e2e tests
           command: yarn test:e2e:android
+      - run:
+          name: Run e2e tests for Next storage
+          command: yarn detox test -c android.emu.release.next --maxConcurrency 1
 
   Release:
     <<: *js_defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -297,6 +297,9 @@ jobs:
           name: Run e2e tests
           command: yarn test:e2e:android
       - run:
+          name: Clear previous app from device
+          command: adb uninstall com.microsoft.reacttestapp
+      - run:
           name: Run e2e tests for Next storage
           command: yarn detox test -c android.emu.release.next --maxConcurrency 1
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -208,22 +208,10 @@ jobs:
           name: Run e2e tests
           command: yarn test:e2e:ios
 
-
   "Build: Android release apk":
     <<: *android_defaults
     steps:
       - *addWorkspace
-#      - restore-cache: *cache_restore_yarn
-#      - run:
-#          name: Installing Yarn dependencies
-#          command: yarn --pure-lockfile --non-interactive --cache-folder ~/.cache/yarn
-#      - save-cache: *cache_save_yarn
-#      - restore-cache: *cache_restore_gradle
-#      - run:
-#          name: Downloading Gradle dependencies
-#          working_directory: example/android
-#          command: ./gradlew --max-workers 2 fetchDependencies
-#      - save-cache: *cache_save_gradle
       - run:
           name: Bundle JS
           command: yarn bundle:android --dev false
@@ -293,7 +281,7 @@ jobs:
                 -no-snapshot \
                 -no-boot-anim \
                 -no-window \
-                -logcat '*:W' | grep -i "ReactNative"
+                -logcat '*:E ReactNative:W ReactNativeJS:*'
       - run:
           name: Wait for emulator to boot
           command: ./scripts/android_e2e.sh 'wait_for_emulator'

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -108,12 +108,13 @@ dependencies {
         def room_version = "2.2.6"
         def coroutines_version = "1.4.2"
         def junit_version = "4.12"
-        def robolectric_version = "4.2.1"
+        def robolectric_version = "4.5.1"
         def truth_version = "1.1.2"
         def androidxtest_version = "1.1.0"
         def coroutinesTest_version = "1.4.2"
 
         implementation "androidx.room:room-runtime:$room_version"
+        implementation "androidx.room:room-ktx:$room_version"
         implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutines_version"
         kapt "androidx.room:room-compiler:$room_version"
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -61,12 +61,9 @@ if( newDbSize != null && newDbSize.isLong()) {
 
 // Instead of reusing AsyncTask thread pool, AsyncStorage can use its own executor
 def useDedicatedExecutor = getFlagOrDefault('AsyncStorage_dedicatedExecutor', false)
-
-apply plugin: 'com.android.library'
-
-// todo: decide the name
 def useRoomImplementation = getFlagOrDefault("AsyncStorage_useRoomLibrary", false)
 
+apply plugin: 'com.android.library'
 if(useRoomImplementation) {
     apply plugin: 'kotlin-android'
     apply plugin: 'kotlin-kapt'
@@ -97,6 +94,16 @@ repositories {
 }
 
 dependencies {
+
+    if(useRoomImplementation) {
+        def room_version = "2.2.6"
+        def coroutines_version = "1.3.9"
+
+        implementation "androidx.room:room-runtime:$room_version"
+        implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutines_version"
+        kapt "androidx.room:room-compiler:$room_version"
+    }
+
     //noinspection GradleDynamicVersion
     implementation 'com.facebook.react:react-native:+'  // From node_modules
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -61,6 +61,8 @@ if (newDbSize != null && newDbSize.isLong()) {
 
 // Instead of reusing AsyncTask thread pool, AsyncStorage can use its own executor
 def useDedicatedExecutor = getFlagOrDefault('AsyncStorage_dedicatedExecutor', false)
+
+// Use next storage implementation
 def useNextStorage = getFlagOrDefault("AsyncStorage_useNextStorage", false)
 
 apply plugin: 'com.android.library'

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -61,10 +61,10 @@ if( newDbSize != null && newDbSize.isLong()) {
 
 // Instead of reusing AsyncTask thread pool, AsyncStorage can use its own executor
 def useDedicatedExecutor = getFlagOrDefault('AsyncStorage_dedicatedExecutor', false)
-def useRoomImplementation = getFlagOrDefault("AsyncStorage_useRoomLibrary", false)
+def useNext = getFlagOrDefault("AsyncStorage_useNext", false)
 
 apply plugin: 'com.android.library'
-if(useRoomImplementation) {
+if(useNext) {
     apply plugin: 'kotlin-android'
     apply plugin: 'kotlin-kapt'
 }
@@ -77,7 +77,7 @@ android {
         targetSdkVersion safeExtGet('targetSdkVersion', 28)
         buildConfigField "Long", "AsyncStorage_db_size", "${dbSizeInMB}L"
         buildConfigField "boolean", "AsyncStorage_useDedicatedExecutor", "${useDedicatedExecutor}"
-        buildConfigField "boolean", "AsyncStorage_useRoomLibrary", "${useRoomImplementation}"
+        buildConfigField "boolean", "AsyncStorage_useNext", "${useNext}"
     }
     lintOptions {
         abortOnError false
@@ -95,7 +95,7 @@ repositories {
 
 dependencies {
 
-    if(useRoomImplementation) {
+    if(useNext) {
         def room_version = "2.2.6"
         def coroutines_version = "1.3.9"
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -55,7 +55,7 @@ buildscript {
 // If you really need bigger size, please keep in mind the potential consequences.
 long dbSizeInMB = 6L
 def newDbSize = rootProject.properties['AsyncStorage_db_size_in_MB']
-if( newDbSize != null && newDbSize.isLong()) {
+if (newDbSize != null && newDbSize.isLong()) {
     dbSizeInMB = newDbSize.toLong()
 }
 
@@ -64,9 +64,10 @@ def useDedicatedExecutor = getFlagOrDefault('AsyncStorage_dedicatedExecutor', fa
 def useNextStorage = getFlagOrDefault("AsyncStorage_useNextStorage", false)
 
 apply plugin: 'com.android.library'
-if(useNextStorage) {
+if (useNextStorage) {
     apply plugin: 'kotlin-android'
     apply plugin: 'kotlin-kapt'
+    apply from: './testresults.gradle'
 }
 
 android {
@@ -82,6 +83,12 @@ android {
     lintOptions {
         abortOnError false
     }
+
+    if (useNextStorage) {
+        testOptions {
+            unitTests.returnDefaultValues = true
+        }
+    }
 }
 
 repositories {
@@ -95,13 +102,26 @@ repositories {
 
 dependencies {
 
-    if(useNextStorage) {
+    if (useNextStorage) {
         def room_version = "2.2.6"
-        def coroutines_version = "1.3.9"
+        def coroutines_version = "1.4.2"
+        def junit_version = "4.12"
+        def robolectric_version = "4.2.1"
+        def truth_version = "1.1.2"
+        def androidxtest_version = "1.1.0"
+        def coroutinesTest_version = "1.4.2"
 
         implementation "androidx.room:room-runtime:$room_version"
         implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutines_version"
         kapt "androidx.room:room-compiler:$room_version"
+
+        testImplementation "junit:junit:$junit_version"
+        testImplementation "androidx.test:runner:$androidxtest_version"
+        testImplementation "androidx.test:rules:$androidxtest_version"
+        testImplementation "androidx.test.ext:junit:$androidxtest_version"
+        testImplementation "org.robolectric:robolectric:$robolectric_version"
+        testImplementation "com.google.truth:truth:$truth_version"
+        testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:$coroutinesTest_version"
     }
 
     //noinspection GradleDynamicVersion

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -61,10 +61,10 @@ if( newDbSize != null && newDbSize.isLong()) {
 
 // Instead of reusing AsyncTask thread pool, AsyncStorage can use its own executor
 def useDedicatedExecutor = getFlagOrDefault('AsyncStorage_dedicatedExecutor', false)
-def useNext = getFlagOrDefault("AsyncStorage_useNext", false)
+def useNextStorage = getFlagOrDefault("AsyncStorage_useNextStorage", false)
 
 apply plugin: 'com.android.library'
-if(useNext) {
+if(useNextStorage) {
     apply plugin: 'kotlin-android'
     apply plugin: 'kotlin-kapt'
 }
@@ -77,7 +77,7 @@ android {
         targetSdkVersion safeExtGet('targetSdkVersion', 28)
         buildConfigField "Long", "AsyncStorage_db_size", "${dbSizeInMB}L"
         buildConfigField "boolean", "AsyncStorage_useDedicatedExecutor", "${useDedicatedExecutor}"
-        buildConfigField "boolean", "AsyncStorage_useNext", "${useNext}"
+        buildConfigField "boolean", "AsyncStorage_useNextStorage", "${useNextStorage}"
     }
     lintOptions {
         abortOnError false
@@ -95,7 +95,7 @@ repositories {
 
 dependencies {
 
-    if(useNext) {
+    if(useNextStorage) {
         def room_version = "2.2.6"
         def coroutines_version = "1.3.9"
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -21,18 +21,30 @@ def safeExtGet(prop, fallback) {
     rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
 }
 
+def getFlagOrDefault(flagName, defaultValue) {
+    rootProject.hasProperty(flagName) ? rootProject.properties[flagName] == "true" : defaultValue
+}
+
 configurations {
     compileClasspath
 }
 
 buildscript {
-    if (project == rootProject) {
-        repositories {
-            google()
-            jcenter()
-        }
-        dependencies {
+    // kotlin version is dictated by rootProject extension or property in gradle.properties
+    ext.asyncStorageKtVersion = rootProject.ext.has('kotlinVersion')
+            ? rootProject.ext['kotlinVersion']
+            : rootProject.hasProperty('AsyncStorage_kotlinVersion')
+            ? rootProject.properties['AsyncStorage_kotlinVersion']
+            : '1.4.21'
+
+    repositories {
+        google()
+        jcenter()
+    }
+    dependencies {
+        if (project == rootProject) {
             classpath 'com.android.tools.build:gradle:3.6.4'
+            classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$asyncStorageKtVersion"
         }
     }
 }
@@ -42,18 +54,23 @@ buildscript {
 // This also protects the database from filling up the disk cache and becoming malformed.
 // If you really need bigger size, please keep in mind the potential consequences.
 long dbSizeInMB = 6L
-
 def newDbSize = rootProject.properties['AsyncStorage_db_size_in_MB']
-
 if( newDbSize != null && newDbSize.isLong()) {
     dbSizeInMB = newDbSize.toLong()
 }
 
-def useDedicatedExecutor = rootProject.hasProperty('AsyncStorage_dedicatedExecutor')
-        ? rootProject.properties['AsyncStorage_dedicatedExecutor']
-        : false
+// Instead of reusing AsyncTask thread pool, AsyncStorage can use its own executor
+def useDedicatedExecutor = getFlagOrDefault('AsyncStorage_dedicatedExecutor', false)
 
 apply plugin: 'com.android.library'
+
+// todo: decide the name
+def useRoomImplementation = getFlagOrDefault("AsyncStorage_useRoomLibrary", false)
+
+if(useRoomImplementation) {
+    apply plugin: 'kotlin-android'
+    apply plugin: 'kotlin-kapt'
+}
 
 android {
     compileSdkVersion safeExtGet('compileSdkVersion', 28)
@@ -62,7 +79,8 @@ android {
         minSdkVersion safeExtGet('minSdkVersion', 19)
         targetSdkVersion safeExtGet('targetSdkVersion', 28)
         buildConfigField "Long", "AsyncStorage_db_size", "${dbSizeInMB}L"
-        buildConfigField("boolean", "AsyncStorage_useDedicatedExecutor", "${useDedicatedExecutor}")
+        buildConfigField "boolean", "AsyncStorage_useDedicatedExecutor", "${useDedicatedExecutor}"
+        buildConfigField "boolean", "AsyncStorage_useRoomLibrary", "${useRoomImplementation}"
     }
     lintOptions {
         abortOnError false

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,0 +1,1 @@
+android.useAndroidX=true

--- a/android/src/main/java/com/reactnativecommunity/asyncstorage/AsyncStorageModule.java
+++ b/android/src/main/java/com/reactnativecommunity/asyncstorage/AsyncStorageModule.java
@@ -46,37 +46,6 @@ public final class AsyncStorageModule
   private ReactDatabaseSupplier mReactDatabaseSupplier;
   private boolean mShuttingDown = false;
 
-  // Adapted from https://android.googlesource.com/platform/frameworks/base.git/+/1488a3a19d4681a41fb45570c15e14d99db1cb66/core/java/android/os/AsyncTask.java#237
-  private class SerialExecutor implements Executor {
-    private final ArrayDeque<Runnable> mTasks = new ArrayDeque<Runnable>();
-    private Runnable mActive;
-    private final Executor executor;
-
-    SerialExecutor(Executor executor) {
-      this.executor = executor;
-    }
-
-    public synchronized void execute(final Runnable r) {
-      mTasks.offer(new Runnable() {
-        public void run() {
-          try {
-            r.run();
-          } finally {
-            scheduleNext();
-          }
-        }
-      });
-      if (mActive == null) {
-        scheduleNext();
-      }
-    }
-    synchronized void scheduleNext() {
-      if ((mActive = mTasks.poll()) != null) {
-        executor.execute(mActive);
-      }
-    }
-  }
-
   private final SerialExecutor executor;
 
   public AsyncStorageModule(ReactApplicationContext reactContext) {

--- a/android/src/main/java/com/reactnativecommunity/asyncstorage/AsyncStoragePackage.java
+++ b/android/src/main/java/com/reactnativecommunity/asyncstorage/AsyncStoragePackage.java
@@ -24,7 +24,7 @@ public class AsyncStoragePackage implements ReactPackage {
 
         List<NativeModule> moduleList = new ArrayList<>(1);
 
-        if (BuildConfig.AsyncStorage_useNext) {
+        if (BuildConfig.AsyncStorage_useNextStorage) {
             try {
                 Class storageClass = Class.forName("com.reactnativecommunity.asyncstorage.next.StorageModule");
                 NativeModule inst = (NativeModule) storageClass.getDeclaredConstructor(new Class[]{ReactContext.class}).newInstance(reactContext);

--- a/android/src/main/java/com/reactnativecommunity/asyncstorage/AsyncStoragePackage.java
+++ b/android/src/main/java/com/reactnativecommunity/asyncstorage/AsyncStoragePackage.java
@@ -7,12 +7,13 @@
 
 package com.reactnativecommunity.asyncstorage;
 
+import android.util.Log;
 import com.facebook.react.ReactPackage;
 import com.facebook.react.bridge.JavaScriptModule;
 import com.facebook.react.bridge.NativeModule;
 import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.uimanager.ViewManager;
-import com.reactnativecommunity.asyncstorage.next.StorageModule;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -23,23 +24,35 @@ public class AsyncStoragePackage implements ReactPackage {
 
         List<NativeModule> moduleList = new ArrayList<>(1);
 
-        if(BuildConfig.AsyncStorage_useRoomLibrary) {
-            moduleList.add(new StorageModule(reactContext));
+        if (BuildConfig.AsyncStorage_useRoomLibrary) {
+            try {
+                Class storageClass = Class.forName("com.reactnativecommunity.asyncstorage.next.StorageModule");
+                NativeModule inst = (NativeModule) storageClass.getDeclaredConstructor(new Class[]{ReactContext.class}).newInstance(reactContext);
+                moduleList.add(inst);
+            } catch (Exception e) {
+                // todo notify about potential issues
+                String message = "Something went wrong when initializing module:"
+                        + "\n"
+                        + e.getCause().getClass()
+                        + "\n"
+                        + "Cause:" + e.getCause().getLocalizedMessage();
+                Log.e("AsyncStorage_Next", message);
+            }
         } else {
             moduleList.add(new AsyncStorageModule(reactContext));
         }
 
-      return moduleList;
+        return moduleList;
     }
 
     // Deprecated in RN 0.47 
     public List<Class<? extends JavaScriptModule>> createJSModules() {
-      return Collections.emptyList();
+        return Collections.emptyList();
     }
 
     @Override
     @SuppressWarnings("rawtypes")
     public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
-      return Collections.emptyList();
+        return Collections.emptyList();
     }
 }

--- a/android/src/main/java/com/reactnativecommunity/asyncstorage/AsyncStoragePackage.java
+++ b/android/src/main/java/com/reactnativecommunity/asyncstorage/AsyncStoragePackage.java
@@ -24,7 +24,7 @@ public class AsyncStoragePackage implements ReactPackage {
 
         List<NativeModule> moduleList = new ArrayList<>(1);
 
-        if (BuildConfig.AsyncStorage_useRoomLibrary) {
+        if (BuildConfig.AsyncStorage_useNext) {
             try {
                 Class storageClass = Class.forName("com.reactnativecommunity.asyncstorage.next.StorageModule");
                 NativeModule inst = (NativeModule) storageClass.getDeclaredConstructor(new Class[]{ReactContext.class}).newInstance(reactContext);

--- a/android/src/main/java/com/reactnativecommunity/asyncstorage/AsyncStoragePackage.java
+++ b/android/src/main/java/com/reactnativecommunity/asyncstorage/AsyncStoragePackage.java
@@ -30,7 +30,6 @@ public class AsyncStoragePackage implements ReactPackage {
                 NativeModule inst = (NativeModule) storageClass.getDeclaredConstructor(new Class[]{ReactContext.class}).newInstance(reactContext);
                 moduleList.add(inst);
             } catch (Exception e) {
-                // todo notify about potential issues
                 String message = "Something went wrong when initializing module:"
                         + "\n"
                         + e.getCause().getClass()

--- a/android/src/main/java/com/reactnativecommunity/asyncstorage/AsyncStoragePackage.java
+++ b/android/src/main/java/com/reactnativecommunity/asyncstorage/AsyncStoragePackage.java
@@ -12,15 +12,24 @@ import com.facebook.react.bridge.JavaScriptModule;
 import com.facebook.react.bridge.NativeModule;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.uimanager.ViewManager;
-
-import java.util.Arrays;
+import com.reactnativecommunity.asyncstorage.next.StorageModule;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
 public class AsyncStoragePackage implements ReactPackage {
     @Override
     public List<NativeModule> createNativeModules(ReactApplicationContext reactContext) {
-      return Arrays.<NativeModule>asList(new AsyncStorageModule(reactContext));
+
+        List<NativeModule> moduleList = new ArrayList<>(1);
+
+        if(BuildConfig.AsyncStorage_useRoomLibrary) {
+            moduleList.add(new StorageModule(reactContext));
+        } else {
+            moduleList.add(new AsyncStorageModule(reactContext));
+        }
+
+      return moduleList;
     }
 
     // Deprecated in RN 0.47 

--- a/android/src/main/java/com/reactnativecommunity/asyncstorage/SerialExecutor.java
+++ b/android/src/main/java/com/reactnativecommunity/asyncstorage/SerialExecutor.java
@@ -1,0 +1,35 @@
+package com.reactnativecommunity.asyncstorage;
+
+import java.util.ArrayDeque;
+import java.util.concurrent.Executor;
+
+// Adapted from https://android.googlesource.com/platform/frameworks/base.git/+/1488a3a19d4681a41fb45570c15e14d99db1cb66/core/java/android/os/AsyncTask.java#237
+public class SerialExecutor implements Executor {
+    private final ArrayDeque<Runnable> mTasks = new ArrayDeque<Runnable>();
+    private Runnable mActive;
+    private final Executor executor;
+
+    public SerialExecutor(Executor executor) {
+        this.executor = executor;
+    }
+
+    public synchronized void execute(final Runnable r) {
+        mTasks.offer(new Runnable() {
+            public void run() {
+                try {
+                    r.run();
+                } finally {
+                    scheduleNext();
+                }
+            }
+        });
+        if (mActive == null) {
+            scheduleNext();
+        }
+    }
+    synchronized void scheduleNext() {
+        if ((mActive = mTasks.poll()) != null) {
+            executor.execute(mActive);
+        }
+    }
+}

--- a/android/src/main/java/com/reactnativecommunity/asyncstorage/SerialExecutor.java
+++ b/android/src/main/java/com/reactnativecommunity/asyncstorage/SerialExecutor.java
@@ -3,7 +3,12 @@ package com.reactnativecommunity.asyncstorage;
 import java.util.ArrayDeque;
 import java.util.concurrent.Executor;
 
-// Adapted from https://android.googlesource.com/platform/frameworks/base.git/+/1488a3a19d4681a41fb45570c15e14d99db1cb66/core/java/android/os/AsyncTask.java#237
+/**
+ * Detox is using this implementation detail in its environment setup,
+ * so in order for Next storage to work, this class has been made public
+ *
+ * Adapted from https://android.googlesource.com/platform/frameworks/base.git/+/1488a3a19d4681a41fb45570c15e14d99db1cb66/core/java/android/os/AsyncTask.java#237
+ */
 public class SerialExecutor implements Executor {
     private final ArrayDeque<Runnable> mTasks = new ArrayDeque<Runnable>();
     private Runnable mActive;

--- a/android/src/main/java/com/reactnativecommunity/asyncstorage/next/ArgumentHelpers.kt
+++ b/android/src/main/java/com/reactnativecommunity/asyncstorage/next/ArgumentHelpers.kt
@@ -1,0 +1,50 @@
+package com.reactnativecommunity.asyncstorage.next
+
+import com.facebook.react.bridge.Arguments
+import com.facebook.react.bridge.ReadableArray
+
+fun ReadableArray.toEntryList(): List<Entry> {
+    val list = mutableListOf<Entry>()
+    for (keyValue in this.toArrayList()) {
+        if (keyValue !is ArrayList<*>) {
+            throw AsyncStorageError.invalidKeyValueFormat()
+        }
+        val key = keyValue[0]
+        val value = keyValue[1]
+
+        if (key == null || key !is String) {
+            throw AsyncStorageError.keyIsNull()
+        }
+
+        if (value !is String) {
+            throw AsyncStorageError.valueNotString(key)
+        }
+
+        list.add(Entry(key, value))
+    }
+    return list
+}
+
+fun ReadableArray.toKeyList(): List<String> {
+    val list = this.toArrayList().toList()
+
+    for (item in list) {
+        if (item !is String) {
+            throw AsyncStorageError.keyIsNull()
+        }
+    }
+    return list as List<String>
+}
+
+fun List<Entry>.toKeyValueArgument(): ReadableArray {
+    val args = Arguments.createArray()
+
+    for (entry in this) {
+        val keyValue = Arguments.createArray()
+        keyValue.pushString(entry.key)
+        keyValue.pushString(entry.value)
+        args.pushArray(keyValue)
+    }
+
+    return args
+}

--- a/android/src/main/java/com/reactnativecommunity/asyncstorage/next/ArgumentHelpers.kt
+++ b/android/src/main/java/com/reactnativecommunity/asyncstorage/next/ArgumentHelpers.kt
@@ -35,7 +35,7 @@ fun ReadableArray.toKeyList(): List<String> {
 
     for (item in list) {
         if (item !is String) {
-            throw AsyncStorageError.keyIsNull()
+            throw AsyncStorageError.keyNotString()
         }
     }
     return list as List<String>

--- a/android/src/main/java/com/reactnativecommunity/asyncstorage/next/ArgumentHelpers.kt
+++ b/android/src/main/java/com/reactnativecommunity/asyncstorage/next/ArgumentHelpers.kt
@@ -2,6 +2,8 @@ package com.reactnativecommunity.asyncstorage.next
 
 import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.ReadableArray
+import org.json.JSONException
+import org.json.JSONObject
 
 fun ReadableArray.toEntryList(): List<Entry> {
     val list = mutableListOf<Entry>()
@@ -50,4 +52,35 @@ fun List<Entry>.toKeyValueArgument(): ReadableArray {
     }
 
     return args
+}
+
+fun String?.isValidJson(): Boolean {
+    if (this == null) return false
+
+    return try {
+        JSONObject(this)
+        true
+    } catch (e: JSONException) {
+        false
+    }
+}
+
+fun JSONObject.mergeWith(newObject: JSONObject): JSONObject {
+
+    val keys = newObject.keys()
+    val mergedObject = JSONObject(this.toString())
+
+    while (keys.hasNext()) {
+        val key = keys.next()
+        val curValue = this.optJSONObject(key)
+        val newValue = newObject.optJSONObject(key)
+
+        if (curValue != null && newValue != null) {
+            val merged = curValue.mergeWith(newValue)
+            mergedObject.put(key, merged)
+        } else {
+            mergedObject.put(key, newObject.get(key))
+        }
+    }
+    return mergedObject
 }

--- a/android/src/main/java/com/reactnativecommunity/asyncstorage/next/ArgumentHelpers.kt
+++ b/android/src/main/java/com/reactnativecommunity/asyncstorage/next/ArgumentHelpers.kt
@@ -6,14 +6,17 @@ import com.facebook.react.bridge.ReadableArray
 fun ReadableArray.toEntryList(): List<Entry> {
     val list = mutableListOf<Entry>()
     for (keyValue in this.toArrayList()) {
-        if (keyValue !is ArrayList<*>) {
+        if (keyValue !is ArrayList<*> || keyValue.size != 2) {
             throw AsyncStorageError.invalidKeyValueFormat()
         }
         val key = keyValue[0]
         val value = keyValue[1]
 
         if (key == null || key !is String) {
-            throw AsyncStorageError.keyIsNull()
+            when (key) {
+                null -> throw AsyncStorageError.keyIsNull()
+                !is String -> throw AsyncStorageError.keyNotString()
+            }
         }
 
         if (value !is String) {
@@ -26,7 +29,7 @@ fun ReadableArray.toEntryList(): List<Entry> {
 }
 
 fun ReadableArray.toKeyList(): List<String> {
-    val list = this.toArrayList().toList()
+    val list = this.toArrayList()
 
     for (item in list) {
         if (item !is String) {

--- a/android/src/main/java/com/reactnativecommunity/asyncstorage/next/ArgumentHelpers.kt
+++ b/android/src/main/java/com/reactnativecommunity/asyncstorage/next/ArgumentHelpers.kt
@@ -14,10 +14,10 @@ fun ReadableArray.toEntryList(): List<Entry> {
         val key = keyValue[0]
         val value = keyValue[1]
 
-        if (key == null || key !is String) {
+        if (key !is String) {
             when (key) {
                 null -> throw AsyncStorageError.keyIsNull()
-                !is String -> throw AsyncStorageError.keyNotString()
+                else -> throw AsyncStorageError.keyNotString()
             }
         }
 

--- a/android/src/main/java/com/reactnativecommunity/asyncstorage/next/ErrorHelpers.kt
+++ b/android/src/main/java/com/reactnativecommunity/asyncstorage/next/ErrorHelpers.kt
@@ -23,14 +23,17 @@ internal class AsyncStorageError private constructor(val errorMessage: String) :
     Throwable(errorMessage) {
 
     companion object {
-        fun keyIsNull() = AsyncStorageError("Key cannot be null")
+        fun keyIsNull() = AsyncStorageError("Key cannot be null.")
+
+        fun keyNotString() = AsyncStorageError("Provided key is not string. Only strings are supported as storage key.")
+
+        fun valueNotString(key: String?): AsyncStorageError {
+            val detail = if (key == null) "Provided value" else "Value for key \"$key\""
+            return AsyncStorageError("$detail is not a string. Only strings are supported as a value.")
+        }
 
         fun invalidKeyValueFormat() =
             AsyncStorageError("Invalid key-value format. Expected a list of [key, value] list.")
 
-        fun valueNotString(key: String?): AsyncStorageError {
-            val detail = if (key == null) "Provided value" else "Value for key \"$key\""
-            return AsyncStorageError("$detail is not of type String")
-        }
     }
 }

--- a/android/src/main/java/com/reactnativecommunity/asyncstorage/next/ErrorHelpers.kt
+++ b/android/src/main/java/com/reactnativecommunity/asyncstorage/next/ErrorHelpers.kt
@@ -1,0 +1,36 @@
+package com.reactnativecommunity.asyncstorage.next
+
+import com.facebook.react.bridge.Arguments
+import com.facebook.react.bridge.Callback
+import kotlinx.coroutines.CoroutineExceptionHandler
+
+internal fun createExceptionHandler(cb: Callback): CoroutineExceptionHandler {
+    return CoroutineExceptionHandler { _, throwable ->
+        val error = Arguments.createMap()
+        if (throwable !is AsyncStorageError) {
+            error.putString(
+                "message", "Unexpected AsyncStorage error: ${throwable.localizedMessage}"
+            )
+        } else {
+            error.putString("message", throwable.errorMessage)
+        }
+
+        cb(error)
+    }
+}
+
+internal class AsyncStorageError private constructor(val errorMessage: String) :
+    Throwable(errorMessage) {
+
+    companion object {
+        fun keyIsNull() = AsyncStorageError("Key cannot be null")
+
+        fun invalidKeyValueFormat() =
+            AsyncStorageError("Invalid key-value format. Expected a list of [key, value] list.")
+
+        fun valueNotString(key: String?): AsyncStorageError {
+            val detail = if (key == null) "Provided value" else "Value for key \"$key\""
+            return AsyncStorageError("$detail is not of type String")
+        }
+    }
+}

--- a/android/src/main/java/com/reactnativecommunity/asyncstorage/next/StorageModule.kt
+++ b/android/src/main/java/com/reactnativecommunity/asyncstorage/next/StorageModule.kt
@@ -1,5 +1,6 @@
 package com.reactnativecommunity.asyncstorage.next
 
+import android.content.Context
 import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.Callback
 import com.facebook.react.bridge.ReactContext
@@ -20,10 +21,16 @@ class StorageModule(reactContext: ReactContext) : ReactContextBaseJavaModule(), 
 
     private val storage = StorageSupplier.getInstance(reactContext)
 
+    companion object {
+        @JvmStatic
+        fun getStorageInstance(ctx: Context): AsyncStorageAccess {
+            return StorageSupplier.getInstance(ctx)
+        }
+    }
+
     /**
      * Todo:
-     *  - Documenting the migration,
-     *  - access from Native (Java interop)
+     *  - DB tests
      */
 
     @ReactMethod

--- a/android/src/main/java/com/reactnativecommunity/asyncstorage/next/StorageModule.kt
+++ b/android/src/main/java/com/reactnativecommunity/asyncstorage/next/StorageModule.kt
@@ -1,0 +1,8 @@
+package com.reactnativecommunity.asyncstorage.next
+
+import com.facebook.react.bridge.ReactContext
+import com.facebook.react.bridge.ReactContextBaseJavaModule
+
+class StorageModule(private val reactContext: ReactContext) : ReactContextBaseJavaModule() {
+    override fun getName() = "RNC_AsyncSQLiteDBStorage"
+}

--- a/android/src/main/java/com/reactnativecommunity/asyncstorage/next/StorageModule.kt
+++ b/android/src/main/java/com/reactnativecommunity/asyncstorage/next/StorageModule.kt
@@ -23,6 +23,7 @@ class StorageModule(reactContext: ReactContext) : ReactContextBaseJavaModule(), 
     /**
      * Todo:
      *  - MultiMerge
+     *  - Documenting the migration, access from Brownfield and error handling
      */
 
     @ReactMethod

--- a/android/src/main/java/com/reactnativecommunity/asyncstorage/next/StorageModule.kt
+++ b/android/src/main/java/com/reactnativecommunity/asyncstorage/next/StorageModule.kt
@@ -22,8 +22,8 @@ class StorageModule(reactContext: ReactContext) : ReactContextBaseJavaModule(), 
 
     /**
      * Todo:
-     *  - MultiMerge
-     *  - Documenting the migration, access from Brownfield and error handling
+     *  - Documenting the migration,
+     *  - access from Native (Java interop)
      */
 
     @ReactMethod
@@ -51,8 +51,14 @@ class StorageModule(reactContext: ReactContext) : ReactContextBaseJavaModule(), 
         }
     }
 
-    // @ReactMethod
-    // fun multiMerge(val keyValueArray: ReadableArray, cb: Callback) {}
+    @ReactMethod
+    fun multiMerge(keyValueArray: ReadableArray, cb: Callback) {
+        launch(createExceptionHandler(cb)) {
+            val entries = keyValueArray.toEntryList()
+            storage.mergeValues(entries)
+            cb(null)
+        }
+    }
 
     @ReactMethod
     fun getAllKeys(cb: Callback) {

--- a/android/src/main/java/com/reactnativecommunity/asyncstorage/next/StorageModule.kt
+++ b/android/src/main/java/com/reactnativecommunity/asyncstorage/next/StorageModule.kt
@@ -1,20 +1,28 @@
 package com.reactnativecommunity.asyncstorage.next
 
 import android.content.Context
+import androidx.annotation.VisibleForTesting
 import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.Callback
 import com.facebook.react.bridge.ReactContext
 import com.facebook.react.bridge.ReactContextBaseJavaModule
 import com.facebook.react.bridge.ReactMethod
 import com.facebook.react.bridge.ReadableArray
+import com.reactnativecommunity.asyncstorage.SerialExecutor
 import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.asExecutor
 import kotlinx.coroutines.launch
 
 class StorageModule(reactContext: ReactContext) : ReactContextBaseJavaModule(), CoroutineScope {
     override fun getName() = "RNC_AsyncSQLiteDBStorage"
+
+    // this executor is here only to please detox, which relies on internal implementation
+    // of current Async Storage
+    @VisibleForTesting
+    private val executor = SerialExecutor(Dispatchers.Main.asExecutor())
 
     override val coroutineContext =
         Dispatchers.IO + CoroutineName("AsyncStorageScope") + SupervisorJob()

--- a/android/src/main/java/com/reactnativecommunity/asyncstorage/next/StorageModule.kt
+++ b/android/src/main/java/com/reactnativecommunity/asyncstorage/next/StorageModule.kt
@@ -28,11 +28,6 @@ class StorageModule(reactContext: ReactContext) : ReactContextBaseJavaModule(), 
         }
     }
 
-    /**
-     * Todo:
-     *  - DB tests
-     */
-
     @ReactMethod
     fun multiGet(keys: ReadableArray, cb: Callback) {
         launch(createExceptionHandler(cb)) {

--- a/android/src/main/java/com/reactnativecommunity/asyncstorage/next/StorageModule.kt
+++ b/android/src/main/java/com/reactnativecommunity/asyncstorage/next/StorageModule.kt
@@ -1,8 +1,32 @@
 package com.reactnativecommunity.asyncstorage.next
 
+import com.facebook.react.bridge.Arguments
+import com.facebook.react.bridge.Callback
 import com.facebook.react.bridge.ReactContext
 import com.facebook.react.bridge.ReactContextBaseJavaModule
+import com.facebook.react.bridge.ReactMethod
+import com.facebook.react.bridge.ReadableArray
+import kotlinx.coroutines.CoroutineName
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
 
-class StorageModule(private val reactContext: ReactContext) : ReactContextBaseJavaModule() {
+class StorageModule(reactContext: ReactContext) : ReactContextBaseJavaModule() {
     override fun getName() = "RNC_AsyncSQLiteDBStorage"
+
+    private val storage: AsyncStorageAccess = StorageSupplier.getInstance(reactContext)
+    private val scope = CoroutineScope(
+        Dispatchers.IO + CoroutineName("AsyncStorageCoroutine") + SupervisorJob()
+    )
+
+    @ReactMethod
+    fun getAllKeys(cb: Callback) {
+        scope.launch {
+            val keys = storage.getKeys()
+            val result = Arguments.createArray()
+            keys.forEach { result.pushString(it) }
+            cb.invoke(result)
+        }
+    }
 }

--- a/android/src/main/java/com/reactnativecommunity/asyncstorage/next/StorageModule.kt
+++ b/android/src/main/java/com/reactnativecommunity/asyncstorage/next/StorageModule.kt
@@ -19,8 +19,8 @@ import kotlinx.coroutines.launch
 class StorageModule(reactContext: ReactContext) : ReactContextBaseJavaModule(), CoroutineScope {
     override fun getName() = "RNC_AsyncSQLiteDBStorage"
 
-    // this executor is here only to please detox, which relies on internal implementation
-    // of current Async Storage
+    // this executor is not used by the module, but it must exists here due to
+    // Detox relying on this implementation detail to run
     @VisibleForTesting
     private val executor = SerialExecutor(Dispatchers.Main.asExecutor())
 

--- a/android/src/main/java/com/reactnativecommunity/asyncstorage/next/StorageSupplier.kt
+++ b/android/src/main/java/com/reactnativecommunity/asyncstorage/next/StorageSupplier.kt
@@ -90,13 +90,10 @@ internal interface StorageDao {
 private object MIGRATION_TO_NEXT : Migration(1, 2) {
     override fun migrate(database: SupportSQLiteDatabase) {
         val oldTableName = "catalystLocalStorage" // from ReactDatabaseSupplier
-
         database.execSQL("CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`${COLUMN_KEY}` TEXT NOT NULL, `${COLUMN_VALUE}` TEXT, PRIMARY KEY(`${COLUMN_KEY}`));")
-
         // even if the old AsyncStorage has checks for not nullable keys
         // make sure we don't copy any, to not fail migration
         database.execSQL("DELETE FROM $oldTableName WHERE `${COLUMN_KEY}` IS NULL")
-
         database.execSQL(
             """
             INSERT INTO $TABLE_NAME (`${COLUMN_KEY}`, `${COLUMN_VALUE}`)
@@ -119,18 +116,15 @@ internal abstract class StorageDb : RoomDatabase() {
             if (inst != null) {
                 return inst
             }
-
             synchronized(this) {
                 val oldDbFile = context.getDatabasePath("RKStorage")
                 val db = Room.databaseBuilder(
                     context, StorageDb::class.java, DATABASE_NAME
                 )
-
                 if (oldDbFile.exists()) {
                     // migrate data from old database, if it exists
                     db.createFromFile(oldDbFile).addMigrations(MIGRATION_TO_NEXT)
                 }
-
                 inst = db.build()
                 instance = inst
                 return instance!!
@@ -154,7 +148,6 @@ class StorageSupplier internal constructor(db: StorageDb) : AsyncStorageAccess {
             return StorageSupplier(StorageDb.getDatabase(ctx))
         }
     }
-
     private val access = db.storage()
 
     override suspend fun getValues(keys: List<String>) = access.getValues(keys)

--- a/android/src/main/java/com/reactnativecommunity/asyncstorage/next/StorageSupplier.kt
+++ b/android/src/main/java/com/reactnativecommunity/asyncstorage/next/StorageSupplier.kt
@@ -12,7 +12,6 @@ import androidx.room.Query
 import androidx.room.Room
 import androidx.room.RoomDatabase
 import androidx.room.Transaction
-import androidx.room.Update
 import androidx.room.migration.Migration
 import androidx.sqlite.db.SupportSQLiteDatabase
 import org.json.JSONObject
@@ -35,18 +34,18 @@ internal interface StorageDao {
 
     @Transaction
     @Query("SELECT * FROM $TABLE_NAME WHERE `$COLUMN_KEY` IN (:keys)")
-    fun getValues(keys: List<String>): List<Entry>
+    suspend fun getValues(keys: List<String>): List<Entry>
 
     @Transaction
     @Insert(onConflict = OnConflictStrategy.REPLACE)
-    fun setValues(entries: List<Entry>)
+    suspend fun setValues(entries: List<Entry>)
 
     @Transaction
     @Query("DELETE FROM $TABLE_NAME WHERE `$COLUMN_KEY` in (:keys)")
-    fun removeValues(keys: List<String>)
+    suspend fun removeValues(keys: List<String>)
 
     @Transaction
-    fun mergeValues(entries: List<Entry>) {
+    suspend fun mergeValues(entries: List<Entry>) {
         val currentDbEntries = getValues(entries.map { it.key })
         val newEntries = mutableListOf<Entry>()
 
@@ -67,11 +66,11 @@ internal interface StorageDao {
 
     @Transaction
     @Query("SELECT `$COLUMN_KEY` FROM $TABLE_NAME")
-    fun getKeys(): List<String>
+    suspend fun getKeys(): List<String>
 
     @Transaction
     @Query("DELETE FROM $TABLE_NAME")
-    fun clear()
+    suspend fun clear()
 }
 
 
@@ -148,6 +147,7 @@ class StorageSupplier internal constructor(db: StorageDb) : AsyncStorageAccess {
             return StorageSupplier(StorageDb.getDatabase(ctx))
         }
     }
+
     private val access = db.storage()
 
     override suspend fun getValues(keys: List<String>) = access.getValues(keys)

--- a/android/src/main/java/com/reactnativecommunity/asyncstorage/next/StorageSupplier.kt
+++ b/android/src/main/java/com/reactnativecommunity/asyncstorage/next/StorageSupplier.kt
@@ -1,0 +1,115 @@
+package com.reactnativecommunity.asyncstorage.next
+
+import android.content.Context
+import androidx.room.ColumnInfo
+import androidx.room.Dao
+import androidx.room.Database
+import androidx.room.Entity
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.PrimaryKey
+import androidx.room.Query
+import androidx.room.Room
+import androidx.room.RoomDatabase
+import androidx.room.Transaction
+import androidx.room.Update
+
+private const val DATABASE_NAME = "RKStorage"
+private const val DATABASE_VERSION = 1
+private const val TABLE_NAME = "catalystLocalStorage"
+private const val COLUMN_KEY = "key"
+private const val COLUMN_VALUE = "value"
+
+
+@Entity(tableName = TABLE_NAME, primaryKeys = ["key"])
+data class Entry(
+    @PrimaryKey @ColumnInfo(name = COLUMN_KEY) val key: String,
+    @ColumnInfo(name = COLUMN_VALUE) val value: String
+)
+
+@Dao
+private interface StorageDao {
+
+    // fun mergeValues() // todo
+
+    @Transaction
+    @Query("SELECT * FROM $TABLE_NAME WHERE `$COLUMN_KEY` IN (:keys)")
+    fun getValues(keys: List<String>): List<Entry>
+
+    @Transaction
+    fun setValues(entries: List<Entry>) {
+        val insertResult = insert(entries)
+        with(entries.filterIndexed { i, _ -> insertResult[i] == -1L }) {
+            update(this)
+        }
+    }
+
+    @Transaction
+    @Query("DELETE FROM $TABLE_NAME WHERE `$COLUMN_KEY` in (:keys)")
+    fun removeValues(keys: List<String>)
+
+    @Transaction
+    @Query("SELECT `$COLUMN_KEY` FROM $TABLE_NAME")
+    fun getKeys(): List<String>
+
+    @Transaction
+    @Query("DELETE FROM $TABLE_NAME")
+    fun clear()
+
+
+    // insert and update are components of setValues - not to be used separately
+    @Insert(onConflict = OnConflictStrategy.IGNORE)
+    fun insert(entries: List<Entry>): List<Long>
+    @Update
+    fun update(entries: List<Entry>)
+}
+
+@Database(entities = [Entry::class], version = DATABASE_VERSION, exportSchema = false)
+private abstract class StorageDb : RoomDatabase() {
+    abstract fun storage(): StorageDao
+
+    companion object {
+        private var instance: StorageDb? = null
+
+        fun getDatabase(context: Context): StorageDb {
+            var inst = instance
+            if (inst != null) {
+                return inst
+            }
+
+            synchronized(this) {
+                inst = Room.databaseBuilder(
+                    context, StorageDb::class.java, DATABASE_NAME
+                ).build()
+
+                instance = inst
+                return instance!!
+            }
+        }
+    }
+}
+
+interface AsyncStorageAccess {
+    suspend fun getValue(keys: List<String>): List<Entry>
+    suspend fun setValues(entries: List<Entry>)
+    suspend fun removeValues(keys: List<String>)
+    suspend fun getKeys(): List<String>
+    suspend fun clear()
+    // suspend fun mergeValues() // todo
+}
+
+class StorageSupplier private constructor(db: StorageDb) : AsyncStorageAccess {
+    companion object {
+        fun getInstance(ctx: Context): AsyncStorageAccess {
+            return StorageSupplier(StorageDb.getDatabase(ctx))
+        }
+    }
+
+    private val access = db.storage()
+
+    override suspend fun getValue(keys: List<String>) = access.getValues(keys)
+    override suspend fun setValues(entries: List<Entry>) = access.setValues(entries)
+    override suspend fun removeValues(keys: List<String>) = access.removeValues(keys)
+    override suspend fun getKeys() = access.getKeys()
+    override suspend fun clear() = access.clear()
+}

--- a/android/src/test/java/com/reactnativecommunity/asyncstorage/next/ArgumentHelpersTest.kt
+++ b/android/src/test/java/com/reactnativecommunity/asyncstorage/next/ArgumentHelpersTest.kt
@@ -1,0 +1,88 @@
+package com.reactnativecommunity.asyncstorage.next
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Assert.assertThrows
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.BlockJUnit4ClassRunner
+
+@RunWith(BlockJUnit4ClassRunner::class)
+class ArgumentHelpersTest {
+
+    @Test
+    fun transformsArgumentsToEntryList() {
+        val keyValue1 = arrayListOf("key1", "value1")
+        val keyValue2 = arrayListOf("key2", "value2")
+        val keyValue3 = arrayListOf("key3", "value3")
+
+        val args = createNativeCallArguments(keyValue1, keyValue2, keyValue3)
+
+        assertThat(args.toEntryList()).isEqualTo(
+            listOf(
+                Entry("key1", "value1"),
+                Entry("key2", "value2"),
+                Entry("key3", "value3"),
+            )
+        )
+    }
+
+    @Test
+    fun transfersArgumentsToKeyList() {
+        val keyList = listOf("key1", "key2", "key3")
+
+        val args = createNativeCallArguments("key1", "key2", "key3")
+
+        assertThat(args.toKeyList()).isEqualTo(keyList)
+    }
+
+    @Test
+    fun throwsIfArgumentsNotValidFormat() {
+        val invalid = arrayListOf("invalid")
+        val args = createNativeCallArguments(invalid)
+
+        val error = assertThrows(AsyncStorageError::class.java) {
+            args.toEntryList()
+        }
+
+        assertThat(error is AsyncStorageError).isTrue()
+        assertThat(error).hasMessageThat()
+            .isEqualTo("Invalid key-value format. Expected a list of [key, value] list.")
+    }
+
+    @Test
+    fun throwsIfArgumentKeyIsNullOrNotString() {
+        val argsInvalidNull = createNativeCallArguments(arrayListOf(null, "invalid"))
+
+        val errorArgsInvalidNull = assertThrows(AsyncStorageError::class.java) {
+            argsInvalidNull.toEntryList()
+        }
+        assertThat(errorArgsInvalidNull is AsyncStorageError).isTrue()
+        assertThat(errorArgsInvalidNull).hasMessageThat().isEqualTo("Key cannot be null.")
+
+
+        val notStringArgs = createNativeCallArguments(arrayListOf(123, "invalid"))
+
+        val errorNotString = assertThrows(AsyncStorageError::class.java) {
+            notStringArgs.toEntryList()
+        }
+        assertThat(errorNotString is AsyncStorageError).isTrue()
+        assertThat(errorNotString).hasMessageThat()
+            .isEqualTo("Provided key is not string. Only strings are supported as storage key.")
+    }
+
+    @Test
+    fun throwsIfArgumentValueNotString() {
+        val invalidArgs = createNativeCallArguments(arrayListOf("my_key", 666))
+
+        val error = assertThrows(AsyncStorageError::class.java) {
+            invalidArgs.toEntryList()
+        }
+
+        assertThat(error is AsyncStorageError).isTrue()
+        assertThat(error).hasMessageThat()
+            .isEqualTo("Value for key \"my_key\" is not a string. Only strings are supported as a value.")
+    }
+}
+
+
+

--- a/android/src/test/java/com/reactnativecommunity/asyncstorage/next/ArgumentHelpersTest.kt
+++ b/android/src/test/java/com/reactnativecommunity/asyncstorage/next/ArgumentHelpersTest.kt
@@ -11,12 +11,11 @@ class ArgumentHelpersTest {
 
     @Test
     fun transformsArgumentsToEntryList() {
-        val keyValue1 = arrayListOf("key1", "value1")
-        val keyValue2 = arrayListOf("key2", "value2")
-        val keyValue3 = arrayListOf("key3", "value3")
-
-        val args = createNativeCallArguments(keyValue1, keyValue2, keyValue3)
-
+        val args = createNativeCallArguments(
+            arrayListOf("key1", "value1"),
+            arrayListOf("key2", "value2"),
+            arrayListOf("key3", "value3")
+        )
         assertThat(args.toEntryList()).isEqualTo(
             listOf(
                 Entry("key1", "value1"),
@@ -29,9 +28,7 @@ class ArgumentHelpersTest {
     @Test
     fun transfersArgumentsToKeyList() {
         val keyList = listOf("key1", "key2", "key3")
-
         val args = createNativeCallArguments("key1", "key2", "key3")
-
         assertThat(args.toKeyList()).isEqualTo(keyList)
     }
 
@@ -39,7 +36,6 @@ class ArgumentHelpersTest {
     fun throwsIfArgumentsNotValidFormat() {
         val invalid = arrayListOf("invalid")
         val args = createNativeCallArguments(invalid)
-
         val error = assertThrows(AsyncStorageError::class.java) {
             args.toEntryList()
         }
@@ -52,16 +48,13 @@ class ArgumentHelpersTest {
     @Test
     fun throwsIfArgumentKeyIsNullOrNotString() {
         val argsInvalidNull = createNativeCallArguments(arrayListOf(null, "invalid"))
-
         val errorArgsInvalidNull = assertThrows(AsyncStorageError::class.java) {
             argsInvalidNull.toEntryList()
         }
         assertThat(errorArgsInvalidNull is AsyncStorageError).isTrue()
         assertThat(errorArgsInvalidNull).hasMessageThat().isEqualTo("Key cannot be null.")
 
-
         val notStringArgs = createNativeCallArguments(arrayListOf(123, "invalid"))
-
         val errorNotString = assertThrows(AsyncStorageError::class.java) {
             notStringArgs.toEntryList()
         }
@@ -73,11 +66,9 @@ class ArgumentHelpersTest {
     @Test
     fun throwsIfArgumentValueNotString() {
         val invalidArgs = createNativeCallArguments(arrayListOf("my_key", 666))
-
         val error = assertThrows(AsyncStorageError::class.java) {
             invalidArgs.toEntryList()
         }
-
         assertThat(error is AsyncStorageError).isTrue()
         assertThat(error).hasMessageThat()
             .isEqualTo("Value for key \"my_key\" is not a string. Only strings are supported as a value.")

--- a/android/src/test/java/com/reactnativecommunity/asyncstorage/next/StorageTest.kt
+++ b/android/src/test/java/com/reactnativecommunity/asyncstorage/next/StorageTest.kt
@@ -1,0 +1,152 @@
+package com.reactnativecommunity.asyncstorage.next
+
+import androidx.room.Room
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runBlockingTest
+import org.json.JSONObject
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import kotlin.random.Random
+
+@ExperimentalCoroutinesApi
+@RunWith(AndroidJUnit4::class)
+class AsyncStorageAccessTest {
+
+    private lateinit var asyncStorage: AsyncStorageAccess
+    private lateinit var database: StorageDb
+
+    @Before
+    fun setup() {
+        database = Room.inMemoryDatabaseBuilder(
+            InstrumentationRegistry.getInstrumentation().context, StorageDb::class.java
+        ).allowMainThreadQueries().build()
+
+        asyncStorage = StorageSupplier(database)
+    }
+
+    @After
+    fun tearDown() {
+        database.close()
+    }
+
+    @Test
+    fun performsBasicGetSetRemoveOperations() = runBlockingTest {
+        val entriesCount = 10
+        val entries = createRandomEntries(entriesCount)
+        val keys = entries.map { it.key }
+
+        assertThat(asyncStorage.getValues(keys)).hasSize(0)
+        asyncStorage.setValues(entries)
+        assertThat(asyncStorage.getValues(keys)).hasSize(entriesCount)
+
+        val indicesToRemove = (1..4).map { Random.nextInt(0, entriesCount) }.distinct()
+        val toRemove = entries.filterIndexed { index, _ -> indicesToRemove.contains(index) }
+
+        asyncStorage.removeValues(toRemove.map { it.key })
+        val currentEntries = asyncStorage.getValues(keys)
+        assertThat(currentEntries).hasSize(entriesCount - toRemove.size)
+    }
+
+    @Test
+    fun readsAllKeysAndClearsDb() = runBlockingTest {
+        val entries = createRandomEntries(8)
+        val keys = entries.map { it.key }
+        asyncStorage.setValues(entries)
+        val dbKeys = asyncStorage.getKeys()
+        assertThat(dbKeys).isEqualTo(keys)
+        asyncStorage.clear()
+        assertThat(asyncStorage.getValues(keys)).hasSize(0)
+    }
+
+    @Test
+    fun mergesDeeplyTwoValues() = runBlockingTest {
+        val initialEntry = Entry("key", VALUE_INITIAL)
+        val overrideEntry = Entry("key", VALUE_OVERRIDES)
+
+        asyncStorage.setValues(listOf(initialEntry))
+        asyncStorage.mergeValues(listOf(overrideEntry))
+
+        val current = asyncStorage.getValues(listOf("key"))[0]
+
+        assertThat(current.value).isEqualTo(VALUE_MERGED)
+    }
+
+    @Test
+    fun updatesExistingValues() = runBlockingTest {
+        val key = "test_key"
+        val value = "test_value"
+        val entries = listOf(Entry(key, value))
+
+        assertThat(asyncStorage.getValues(listOf(key))).hasSize(0)
+        asyncStorage.setValues(entries)
+        assertThat(asyncStorage.getValues(listOf(key))).isEqualTo(entries)
+
+        val modifiedEntries = listOf(Entry(key, "updatedValue"))
+
+        asyncStorage.setValues(modifiedEntries)
+        assertThat(asyncStorage.getValues(listOf(key))).isEqualTo(modifiedEntries)
+    }
+
+
+    // Test Helpers
+    private fun createRandomEntries(count: Int = Random.nextInt(10)): List<Entry> {
+        val entries = mutableListOf<Entry>()
+        for (i in 0 until count) {
+            entries.add(Entry("key$i", "value$i"))
+        }
+        return entries
+    }
+
+    private val VALUE_INITIAL = JSONObject(
+        """
+    {
+       "key":"value",
+       "key2":"override",
+       "key3":{
+          "key4":"value4",
+          "key6":{
+             "key7":"value7",
+             "key8":"override"
+          }
+       }
+    }
+""".trimMargin()
+    ).toString()
+
+    private val VALUE_OVERRIDES = JSONObject(
+        """
+    {
+       "key2":"value2",
+       "key3":{
+          "key5":"value5",
+          "key6":{
+             "key8":"value8"
+          }
+       }
+    }
+"""
+    ).toString()
+
+
+    private val VALUE_MERGED = JSONObject(
+        """
+    {
+       "key":"value",
+       "key2":"value2",
+       "key3":{
+          "key4":"value4",
+          "key5":"value5",
+          "key6":{
+             "key7":"value7",
+             "key8":"value8"
+          }
+       }
+    }
+""".trimMargin()
+    ).toString()
+}

--- a/android/src/test/java/com/reactnativecommunity/asyncstorage/next/StorageTest.kt
+++ b/android/src/test/java/com/reactnativecommunity/asyncstorage/next/StorageTest.kt
@@ -16,7 +16,6 @@ import kotlin.random.Random
 @ExperimentalCoroutinesApi
 @RunWith(AndroidJUnit4::class)
 class AsyncStorageAccessTest {
-
     private lateinit var asyncStorage: AsyncStorageAccess
     private lateinit var database: StorageDb
 
@@ -39,14 +38,11 @@ class AsyncStorageAccessTest {
         val entriesCount = 10
         val entries = createRandomEntries(entriesCount)
         val keys = entries.map { it.key }
-
         assertThat(asyncStorage.getValues(keys)).hasSize(0)
         asyncStorage.setValues(entries)
         assertThat(asyncStorage.getValues(keys)).hasSize(entriesCount)
-
         val indicesToRemove = (1..4).map { Random.nextInt(0, entriesCount) }.distinct()
         val toRemove = entries.filterIndexed { index, _ -> indicesToRemove.contains(index) }
-
         asyncStorage.removeValues(toRemove.map { it.key })
         val currentEntries = asyncStorage.getValues(keys)
         assertThat(currentEntries).hasSize(entriesCount - toRemove.size)
@@ -67,12 +63,9 @@ class AsyncStorageAccessTest {
     fun mergesDeeplyTwoValues() = runBlockingTest {
         val initialEntry = Entry("key", VALUE_INITIAL)
         val overrideEntry = Entry("key", VALUE_OVERRIDES)
-
         asyncStorage.setValues(listOf(initialEntry))
         asyncStorage.mergeValues(listOf(overrideEntry))
-
         val current = asyncStorage.getValues(listOf("key"))[0]
-
         assertThat(current.value).isEqualTo(VALUE_MERGED)
     }
 
@@ -81,13 +74,10 @@ class AsyncStorageAccessTest {
         val key = "test_key"
         val value = "test_value"
         val entries = listOf(Entry(key, value))
-
         assertThat(asyncStorage.getValues(listOf(key))).hasSize(0)
         asyncStorage.setValues(entries)
         assertThat(asyncStorage.getValues(listOf(key))).isEqualTo(entries)
-
         val modifiedEntries = listOf(Entry(key, "updatedValue"))
-
         asyncStorage.setValues(modifiedEntries)
         assertThat(asyncStorage.getValues(listOf(key))).isEqualTo(modifiedEntries)
     }

--- a/android/src/test/java/com/reactnativecommunity/asyncstorage/next/StorageTest.kt
+++ b/android/src/test/java/com/reactnativecommunity/asyncstorage/next/StorageTest.kt
@@ -5,7 +5,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.runBlockingTest
+import kotlinx.coroutines.runBlocking
 import org.json.JSONObject
 import org.junit.After
 import org.junit.Before
@@ -24,7 +24,6 @@ class AsyncStorageAccessTest {
         database = Room.inMemoryDatabaseBuilder(
             InstrumentationRegistry.getInstrumentation().context, StorageDb::class.java
         ).allowMainThreadQueries().build()
-
         asyncStorage = StorageSupplier(database)
     }
 
@@ -34,7 +33,7 @@ class AsyncStorageAccessTest {
     }
 
     @Test
-    fun performsBasicGetSetRemoveOperations() = runBlockingTest {
+    fun performsBasicGetSetRemoveOperations() = runBlocking {
         val entriesCount = 10
         val entries = createRandomEntries(entriesCount)
         val keys = entries.map { it.key }
@@ -49,7 +48,7 @@ class AsyncStorageAccessTest {
     }
 
     @Test
-    fun readsAllKeysAndClearsDb() = runBlockingTest {
+    fun readsAllKeysAndClearsDb() = runBlocking {
         val entries = createRandomEntries(8)
         val keys = entries.map { it.key }
         asyncStorage.setValues(entries)
@@ -60,7 +59,7 @@ class AsyncStorageAccessTest {
     }
 
     @Test
-    fun mergesDeeplyTwoValues() = runBlockingTest {
+    fun mergesDeeplyTwoValues() = runBlocking {
         val initialEntry = Entry("key", VALUE_INITIAL)
         val overrideEntry = Entry("key", VALUE_OVERRIDES)
         asyncStorage.setValues(listOf(initialEntry))
@@ -70,7 +69,7 @@ class AsyncStorageAccessTest {
     }
 
     @Test
-    fun updatesExistingValues() = runBlockingTest {
+    fun updatesExistingValues() = runBlocking {
         val key = "test_key"
         val value = "test_value"
         val entries = listOf(Entry(key, value))

--- a/android/src/test/java/com/reactnativecommunity/asyncstorage/next/TestUtils.kt
+++ b/android/src/test/java/com/reactnativecommunity/asyncstorage/next/TestUtils.kt
@@ -1,0 +1,84 @@
+package com.reactnativecommunity.asyncstorage.next
+
+import com.facebook.react.bridge.Dynamic
+import com.facebook.react.bridge.ReadableArray
+import com.facebook.react.bridge.ReadableMap
+import com.facebook.react.bridge.ReadableType
+import com.facebook.react.bridge.WritableArray
+
+fun <T : Any> createNativeCallArguments(vararg list: T): ReadableArray {
+    val args = ArrayList(list.toList())
+    return TestingArguments(args)
+}
+
+internal class TestingArguments<T : Any>(initBackingArray: ArrayList<T> = arrayListOf()) :
+    WritableArray {
+    private val backArray: ArrayList<T> = initBackingArray
+    override fun size() = backArray.size
+
+    override fun toArrayList(): ArrayList<Any> = backArray as ArrayList<Any>
+
+    override fun isNull(index: Int): Boolean {
+        TODO("ignored")
+    }
+
+    override fun getBoolean(index: Int): Boolean {
+        TODO("ignored")
+    }
+
+    override fun getDouble(index: Int): Double {
+        TODO("ignored")
+    }
+
+    override fun getInt(index: Int): Int {
+        TODO("ignored")
+    }
+
+    override fun getString(index: Int): String? {
+        TODO("ignored")
+    }
+
+    override fun getArray(index: Int): ReadableArray? {
+        TODO("ignored")
+    }
+
+    override fun getMap(index: Int): ReadableMap? {
+        TODO("ignored")
+    }
+
+    override fun getDynamic(index: Int): Dynamic {
+        TODO("ignored")
+    }
+
+    override fun getType(index: Int): ReadableType {
+        TODO("ignored")
+    }
+
+    override fun pushNull() {
+        TODO("ignored")
+    }
+
+    override fun pushBoolean(value: Boolean) {
+        TODO("ignored")
+    }
+
+    override fun pushDouble(value: Double) {
+        TODO("ignored")
+    }
+
+    override fun pushInt(value: Int) {
+        TODO("ignored")
+    }
+
+    override fun pushString(value: String?) {
+        TODO("ignored")
+    }
+
+    override fun pushArray(array: ReadableArray?) {
+        TODO("ignore")
+    }
+
+    override fun pushMap(map: ReadableMap?) {
+        TODO("ignored")
+    }
+}

--- a/android/testresults.gradle
+++ b/android/testresults.gradle
@@ -1,0 +1,38 @@
+
+// pretty print test results
+import org.gradle.api.tasks.testing.logging.TestExceptionFormat
+import org.gradle.api.tasks.testing.logging.TestLogEvent
+tasks.withType(Test) {
+    testLogging {
+
+        events TestLogEvent.FAILED,
+                TestLogEvent.PASSED,
+                TestLogEvent.SKIPPED,
+                TestLogEvent.STANDARD_OUT
+        exceptionFormat TestExceptionFormat.FULL
+        showExceptions true
+        showCauses true
+        showStackTraces true
+
+        debug {
+            events TestLogEvent.STARTED,
+                    TestLogEvent.FAILED,
+                    TestLogEvent.PASSED,
+                    TestLogEvent.SKIPPED,
+                    TestLogEvent.STANDARD_ERROR,
+                    TestLogEvent.STANDARD_OUT
+            exceptionFormat TestExceptionFormat.FULL
+        }
+        info.events = debug.events
+        info.exceptionFormat = debug.exceptionFormat
+
+        afterSuite { desc, result ->
+            if (!desc.parent) { // will match the outermost suite
+                def output = "Results: ${result.resultType} (${result.testCount} tests, ${result.successfulTestCount} passed, ${result.failedTestCount} failed, ${result.skippedTestCount} skipped)"
+                def startItem = '|  ', endItem = '  |'
+                def repeatLength = startItem.length() + output.length() + endItem.length()
+                println('\n' + ('-' * repeatLength) + '\n' + startItem + output + endItem + '\n' + ('-' * repeatLength))
+            }
+        }
+    }
+}

--- a/example/App.js
+++ b/example/App.js
@@ -21,6 +21,7 @@ import {
 
 import GetSetClear from './examples/GetSetClear';
 import MergeItem from './examples/MergeItem';
+import BasicExample from './examples/Basic';
 
 const TESTS = {
   GetSetClear: {
@@ -37,6 +38,14 @@ const TESTS = {
     description: 'Merge object with already stored data',
     render() {
       return <MergeItem />;
+    },
+  },
+  Basic: {
+    title: 'Basic',
+    testId: 'basic',
+    description: 'Basic functionality test',
+    render() {
+      return <BasicExample />;
     },
   },
 };
@@ -86,6 +95,10 @@ export default class App extends Component<Props, State> {
             testID="testType_mergeItem"
             title="Merge Item"
             onPress={() => this._changeTest('MergeItem')}
+          />
+          <Button
+            title={TESTS.Basic.title}
+            onPress={() => this._changeTest('Basic')}
           />
         </View>
 

--- a/example/App.js
+++ b/example/App.js
@@ -128,7 +128,7 @@ const styles = StyleSheet.create({
     padding: 8,
   },
   exampleContainer: {
-    padding: 16,
+    padding: 4,
     backgroundColor: '#FFF',
     borderColor: '#EEE',
     borderTopWidth: 1,

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -28,6 +28,14 @@ task fetchDependencies() {
 buildscript {
     ext.kotlinVersion = '1.4.21'
 
+    // Mainly for Detox testing for using Next Storage
+    // when building next, force using next storage
+    if(gradle.startParameter.getTaskNames().contains("assembleNext")) {
+        rootProject.setProperty("AsyncStorage_useNextStorage", "true")
+    }
+    Boolean nextStorageFlag = rootProject.hasProperty("AsyncStorage_useNextStorage") ? rootProject.properties["AsyncStorage_useNextStorage"] == "true" : false
+    println("[Async Storage] Using Next storage: " + nextStorageFlag)
+
     repositories {
         google()
         jcenter()
@@ -64,8 +72,14 @@ allprojects {
                     keyPassword 'android'
                 }
             }
-
             androidExtension.buildTypes.release.signingConfig = androidExtension.signingConfigs.test
+            androidExtension.buildTypes {
+                next {
+                    initWith release
+                    matchingFallbacks = ["debug", "release"]
+                }
+            }
+
             androidExtension.testBuildType = 'release'
 
             androidExtension.sourceSets.androidTest.java.srcDirs += "$rootDir/app/src/androidTest/java"

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -79,11 +79,12 @@ allprojects {
                     matchingFallbacks = ["debug", "release"]
                 }
             }
-
             androidExtension.testBuildType = 'release'
-
             androidExtension.sourceSets.androidTest.java.srcDirs += "$rootDir/app/src/androidTest/java"
-
+            if(System.getenv("CIRCLECI") == "true") {
+                // explicitly apply NDK version available in CI image
+                androidExtension.ndkVersion = "20.1.5948944"
+            }
             project.dependencies {
                 androidTestImplementation('com.wix:detox:+')
             }

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -26,11 +26,6 @@ task fetchDependencies() {
 }
 
 buildscript {
-    /**
-     * Todo:
-     *  In order to use this feature, the end user will have to also include
-     *  Kotlin plugin. Add this info to docs.
-     */
     ext.kotlinVersion = '1.4.21'
 
     repositories {
@@ -40,8 +35,6 @@ buildscript {
     dependencies {
         // Needs to match `react-native-test-app/android/app/build.gradle`
         classpath "com.android.tools.build:gradle:4.0.2"
-
-        // todo: remember to document this as well
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
     }
 }

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -75,6 +75,7 @@ allprojects {
             androidExtension.buildTypes.release.signingConfig = androidExtension.signingConfigs.test
             androidExtension.buildTypes {
                 next {
+                    // this build type is used on CI (to have app with and without nextStorage)
                     initWith release
                     matchingFallbacks = ["debug", "release"]
                 }
@@ -87,6 +88,9 @@ allprojects {
             }
             project.dependencies {
                 androidTestImplementation('com.wix:detox:+')
+
+                def hermesDir = file('../../node_modules/hermes-engine/android').absolutePath
+                nextImplementation files("$hermesDir/hermes-release.aar")
             }
         }
     }

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -26,6 +26,13 @@ task fetchDependencies() {
 }
 
 buildscript {
+    /**
+     * Todo:
+     *  In order to use this feature, the end user will have to also include
+     *  Kotlin plugin. Add this info to docs.
+     */
+    ext.kotlinVersion = '1.4.21'
+
     repositories {
         google()
         jcenter()
@@ -33,6 +40,7 @@ buildscript {
     dependencies {
         // Needs to match `react-native-test-app/android/app/build.gradle`
         classpath "com.android.tools.build:gradle:4.0.2"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
     }
 }
 

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -40,6 +40,8 @@ buildscript {
     dependencies {
         // Needs to match `react-native-test-app/android/app/build.gradle`
         classpath "com.android.tools.build:gradle:4.0.2"
+
+        // todo: remember to document this as well
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
     }
 }

--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -22,7 +22,7 @@
 
 # Enable dedicated thread pool executor
 AsyncStorage_dedicatedExecutor=true
-AsyncStorage_useNext=true
+AsyncStorage_useNextStorage=true
 
 android.useAndroidX=true
 android.enableJetifier=true

--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -22,7 +22,7 @@
 
 # Enable dedicated thread pool executor
 AsyncStorage_dedicatedExecutor=true
-AsyncStorage_useRoomLibrary=true
+AsyncStorage_useNext=true
 
 android.useAndroidX=true
 android.enableJetifier=true

--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -22,6 +22,7 @@
 
 # Enable dedicated thread pool executor
 AsyncStorage_dedicatedExecutor=true
+AsyncStorage_useRoomLibrary=true
 
 android.useAndroidX=true
 android.enableJetifier=true

--- a/example/examples/Basic.js
+++ b/example/examples/Basic.js
@@ -44,21 +44,11 @@ function NextExample() {
   }
 
   async function crashKeyNull() {
-    await AsyncStorage.setItem(null, 435345);
+    await AsyncStorage.setItem(null, '435345');
   }
 
-  function unknownCrash() {
-    // very unlikely to happen, unless module used directly
-    return new Promise((res, rej) => {
-      RCTAsyncStorage.multiSet(['key', 'crash'], function(errors) {
-        if (errors) {
-          const message = Array.isArray(errors) ? errors[0].message : errors.message;
-          rej(new Error(message));
-        } else {
-          res();
-        }
-      });
-    });
+  async function crashKeyNotString() {
+    await AsyncStorage.setItem(432, '435345');
   }
 
   async function removeValue() {
@@ -88,8 +78,8 @@ function NextExample() {
       <Text style={{fontSize: 16, fontWeight: '700'}}>Crash scenarios</Text>
       <View style={{flexDirection: 'row', justifyContent: 'space-around'}}>
         <Button title="Key null" onPress={runWithCatch(crashKeyNull)}/>
+        <Button title="Key not string" onPress={runWithCatch(crashKeyNotString)}/>
         <Button title="Wrong value type" onPress={runWithCatch(crashValueType)}/>
-        <Button title="Other crash" onPress={runWithCatch(unknownCrash)}/>
       </View>
     </View>
 

--- a/example/examples/Basic.js
+++ b/example/examples/Basic.js
@@ -112,8 +112,6 @@ function NextExample() {
         };
       }
     }
-
-
     await AsyncStorage.mergeItem('MERGER', JSON.stringify(toMerge));
   }
 

--- a/example/examples/Basic.js
+++ b/example/examples/Basic.js
@@ -1,0 +1,128 @@
+import React from 'react';
+import {View, Text, Button, StyleSheet, ScrollView, TextInput, NativeModules} from 'react-native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+const RCTAsyncStorage = NativeModules.RNC_AsyncSQLiteDBStorage ||
+  NativeModules.RNCAsyncStorage;
+
+
+function NextExample() {
+  const [keys, setKeys] = React.useState([]);
+  const [error, setError] = React.useState(null);
+  const [inputKey, setInputKey] = React.useState();
+  const [inputValue, setInputValue] = React.useState();
+  const [value, setValue] = React.useState();
+
+
+  function runWithCatch(block) {
+    return async () => {
+      try {
+        setError(null);
+        await block();
+      } catch (e) {
+        setError('Caught: ' + e.message || e);
+      }
+    };
+  }
+
+  async function getAllKeys() {
+    const allKeys = await AsyncStorage.getAllKeys();
+    setKeys(allKeys);
+  }
+
+  async function readValue() {
+    const v = await AsyncStorage.getItem(inputKey);
+    setValue(v);
+  }
+
+  async function saveValue() {
+    await AsyncStorage.setItem(inputKey, inputValue);
+  }
+
+  async function crashValueType() {
+    await AsyncStorage.setItem('CRASH', 435345);
+  }
+
+  async function crashKeyNull() {
+    await AsyncStorage.setItem(null, 435345);
+  }
+
+  function unknownCrash() {
+    // very unlikely to happen, unless module used directly
+    return new Promise((res, rej) => {
+      RCTAsyncStorage.multiSet(['key', 'crash'], function(errors) {
+        if (errors) {
+          const message = Array.isArray(errors) ? errors[0].message : errors.message;
+          rej(new Error(message));
+        } else {
+          res();
+        }
+      });
+    });
+  }
+
+  async function removeValue() {
+    await AsyncStorage.removeItem(inputKey);
+  }
+
+  async function clearDb() {
+    await AsyncStorage.clear();
+  }
+
+  return <ScrollView contentContainerStyle={{flexGrow: 1}}>
+
+    {error ? <Text style={{fontSize: 18, color: 'red'}}>{error}</Text> : null}
+
+    <View style={styles.example}>
+      <TextInput onChangeText={setInputKey} value={inputKey} style={styles.input} placeholder="key"/>
+      <TextInput onChangeText={setInputValue} value={inputValue} style={styles.input} placeholder="value"/>
+      <View style={{flexDirection: 'row', justifyContent: 'space-around'}}>
+        <Button title="Read" onPress={runWithCatch(readValue)}/>
+        <Button title="Save" onPress={runWithCatch(saveValue)}/>
+        <Button title="Delete" onPress={runWithCatch(removeValue)}/>
+      </View>
+      <Text>Value for {inputKey}: {value}</Text>
+    </View>
+
+    <View style={styles.example}>
+      <Text style={{fontSize: 16, fontWeight: '700'}}>Crash scenarios</Text>
+      <View style={{flexDirection: 'row', justifyContent: 'space-around'}}>
+        <Button title="Key null" onPress={runWithCatch(crashKeyNull)}/>
+        <Button title="Wrong value type" onPress={runWithCatch(crashValueType)}/>
+        <Button title="Other crash" onPress={runWithCatch(unknownCrash)}/>
+      </View>
+    </View>
+
+    <View style={styles.example}>
+      <View style={{flexDirection: 'row', justifyContent: 'space-around'}}>
+        <Button title="Get all keys" onPress={runWithCatch(getAllKeys)}/>
+      </View>
+      <Text style={{fontWeight: '700'}}>Keys:</Text>
+      <Text>{keys.join(', ')}</Text>
+    </View>
+
+    <View style={styles.example}>
+      <Text style={{fontSize: 16}}>Clear database entries</Text>
+      <Button title="clear" onPress={runWithCatch(clearDb)}/>
+    </View>
+  </ScrollView>;
+}
+
+
+const styles = StyleSheet.create({
+  example: {
+    paddingVertical: 24,
+    borderBottomWidth: 1,
+    borderBottomColor: '#e3e3e3',
+    borderStyle: 'solid',
+    justifyContent: 'space-between',
+  },
+  input: {
+    borderWidth: 1,
+    borderColor: '#eee',
+    borderStyle: 'solid',
+  },
+});
+
+
+export default NextExample;

--- a/example/examples/GetSetClear.js
+++ b/example/examples/GetSetClear.js
@@ -16,6 +16,7 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 export default function GetSet() {
   const [storedNumber, setStoredNumber] = React.useState('');
   const [needsRestart, setNeedsRestart] = React.useState(false);
+  const [keys, setKeys] = React.useState([]);
 
   React.useEffect(() => {
     AsyncStorage.getItem(STORAGE_KEY).then((value) => {
@@ -23,6 +24,7 @@ export default function GetSet() {
         setStoredNumber(value);
       }
     });
+    AsyncStorage.getAllKeys().then(setKeys);
   }, []);
 
   const increaseByTen = React.useCallback(async () => {
@@ -53,6 +55,8 @@ export default function GetSet() {
       />
 
       <Button testID="clear_button" title="Clear item" onPress={clearItem} />
+
+      <Text>Keys: {keys.join(', ')}</Text>
 
       {needsRestart ? <Text>Hit restart to see effect</Text> : null}
     </View>

--- a/example/examples/GetSetClear.js
+++ b/example/examples/GetSetClear.js
@@ -16,7 +16,6 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 export default function GetSet() {
   const [storedNumber, setStoredNumber] = React.useState('');
   const [needsRestart, setNeedsRestart] = React.useState(false);
-  const [keys, setKeys] = React.useState([]);
 
   React.useEffect(() => {
     AsyncStorage.getItem(STORAGE_KEY).then((value) => {
@@ -24,7 +23,6 @@ export default function GetSet() {
         setStoredNumber(value);
       }
     });
-    AsyncStorage.getAllKeys().then(setKeys);
   }, []);
 
   const increaseByTen = React.useCallback(async () => {
@@ -55,8 +53,6 @@ export default function GetSet() {
       />
 
       <Button testID="clear_button" title="Clear item" onPress={clearItem} />
-
-      <Text>Keys: {keys.join(', ')}</Text>
 
       {needsRestart ? <Text>Hit restart to see effect</Text> : null}
     </View>

--- a/package.json
+++ b/package.json
@@ -128,6 +128,14 @@
         "device": {
           "avdName": "Emu_E2E"
         }
+      },
+      "android.emu.release.next": {
+        "binaryPath": "example/android/app/build/outputs/apk/next/app-next.apk",
+        "testBinaryPath": "example/android/app/build/outputs/apk/androidTest/release/app-release-androidTest.apk",
+        "type": "android.emulator",
+        "device": {
+          "avdName": "Emu_E2E"
+        }
       }
     }
   },

--- a/scripts/android_e2e.sh
+++ b/scripts/android_e2e.sh
@@ -6,7 +6,7 @@ MAX_RETRIES=60 # wait max 5 minutes for emu to boot
 build_apk() {
   echo
   echo "[Detox e2e] Building APK"
-  (cd example/android; ./gradlew assembleRelease assembleAndroidTest -DtestBuildType=release --max-workers 2)
+  (cd example/android; ./gradlew assembleRelease assembleAndroidTest -PAsyncStorage_useNextStorage=false -DtestBuildType=release --max-workers 2)
 }
 
 bundle_js() {

--- a/website/docs/Linking.md
+++ b/website/docs/Linking.md
@@ -5,7 +5,6 @@ sidebar_label: Manual linking
 ---
 
 
-
 ## iOS
 
 #### Project linking

--- a/website/docs/advanced/BrownfieldIntegration.md
+++ b/website/docs/advanced/BrownfieldIntegration.md
@@ -7,8 +7,11 @@ import PlatformSupport from "../../src/components/Platform.js"
 
 **Supported platforms:**
 <PlatformSupport title="iOS/MacOS" platformIcon="icon_ios.svg"></PlatformSupport>
+<PlatformSupport title="Android" platformIcon="icon_android.svg"></PlatformSupport>
 
 ---
+
+# iOS
 
 If you're embedding React Native into native application, you can also integrate
 Async Storage module, so that both worlds will use one storage solution.
@@ -110,3 +113,119 @@ Called by `getItem` and `multiGet` in JS.
 **Optional:** Returns whether the delegate should be treated as a passthrough.
 This is useful for monitoring storage usage among other things. Returns `NO` by
 default.
+
+---
+
+# Android
+
+The recommended approach here is to use Kotlin language to leverage coroutines when accessing the storage.
+Java is also supported (through Kotlin interop), but the approach is more cumbersome.
+
+
+## Prerequisites
+
+1. [Next storage feature](Next.md) enabled.
+2. Add dependency on `coroutines-android` in your app's `build.gradle`
+
+```diff
+
+dependencies {
+  // other dependencies
+
+
+  // will work with coroutines 1.3.0 and up
++ implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.3.9"
+
+}
+```
+
+3. Your library of choice for parsing JSON storage values (since there are strings only)
+
+
+## Access storage
+
+### Kotlin (recommended)
+
+We use Coroutines to handle asynchronous code. Each method on storage is `suspend` method, so you need to
+call it from within a coroutine.
+
+
+#### Reading value
+
+```kotlin
+suspend fun readValue(ctx: Context, keys: List<String>) {
+    // get instance of the Storage by providing context object
+    val asyncStorage = StorageModule.getStorageInstance(ctx)
+
+    val entries: List<Entry> = asyncStorage.getValues(keys)
+    doSomethingWithValues(entries)
+}
+```
+
+#### Saving value
+
+```kotlin
+suspend fun saveValue(ctx: Context) {
+    val asyncStorage = StorageModule.getStorageInstance(ctx)
+
+    val entries = listOf(
+        Entry("myKey", "myValue")
+    )
+    asyncStorage.setValues(entries)
+}
+```
+
+
+### Java
+
+You can access AsyncStorage form Java, but you're still required to add Kotlin dependencies.
+There's no one way of accessing the data and there's more than one way to parse it.
+
+
+#### Reading from storage
+
+```java
+void readStorageValue(Context ctx, String key) {
+    AsyncStorageAccess asyncStorage = StorageModule.getStorageInstance(ctx);
+
+    BuildersKt.launch(GlobalScope.INSTANCE,
+            Dispatchers.getIO(),
+            CoroutineStart.DEFAULT,
+            (scope, continuation) -> {
+                List<String> keys = new ArrayList<>();
+                keys.add(key);
+
+                List<Entry> entries = (List<Entry>) asyncStorage.getValues(keys, (Continuation<? super List<? extends Entry>>) continuation);
+                doSomethingWithValues(entries);
+
+                return Unit.INSTANCE;
+            });
+
+}
+```
+
+
+#### Saving to storage
+
+```java
+void saveStorageValue(Context ctx, String key, String value) {
+  AsyncStorageAccess asyncStorage = StorageModule.getStorageInstance(ctx);
+
+  BuildersKt.launch(GlobalScope.INSTANCE,
+          Dispatchers.getIO(),
+          CoroutineStart.DEFAULT,
+          (scope, continuation) -> {
+
+            List<Entry> entries = new ArrayList<>();
+            Entry entry = new Entry(key, value);
+            entries.add(entry);
+
+            asyncStorage.setValues(entries, continuation);
+
+            return Unit.INSTANCE;
+          });
+}
+```
+
+
+

--- a/website/docs/advanced/DedicatedExecutor.md
+++ b/website/docs/advanced/DedicatedExecutor.md
@@ -10,10 +10,12 @@ import PlatformSupport from "../../src/components/Platform.js"
 
 ---
 
-This feature would be mostly used in brownfield apps and [in edge cases with some android devices.](https://github.com/react-native-async-storage/async-storage/issues/159)
+**Note**: This feature is obsolete when [Next storage feature is enabled](Next.md).
+
 
 ## Motivation
 
+This feature would be mostly used in brownfield apps and [in edge cases with some android devices.](https://github.com/react-native-async-storage/async-storage/issues/159)
 Dedicated thread pool executor makes `AsyncStorage` use separate thread pool for its tasks execution.
 
 Use this feature if `THREAD_POOL_EXECUTOR` from `AsyncTasks`:

--- a/website/docs/advanced/IncreaseDbSize.md
+++ b/website/docs/advanced/IncreaseDbSize.md
@@ -10,9 +10,13 @@ import PlatformSupport from "../../src/components/Platform.js"
 
 ---
 
+**Note**: This feature is obsolete when [Next storage feature is enabled](Next.md).
+
+## Motivation
+
 Current Async Storage's size is set to 6MB. Going over this limit causes `database or disk is full` error. This 6MB limit is a sane limit to protect the user from the app storing too much data in the database. This also protects the database from filling up the disk cache and becoming malformed (endTransaction() calls will throw an exception, not rollback, and leave the db malformed). You have to be aware of that risk when increasing the database size. We recommend to ensure that your app does not write more data to AsyncStorage than space is left on disk. Since AsyncStorage is based on SQLite on Android you also have to be aware of the [SQLite limits](https://www.sqlite.org/limits.html).
 
-### Increase limit
+## Increase limit
 
 Add a `AsyncStorage_db_size_in_MB` property to your `android/gradle.properties`:
 

--- a/website/docs/advanced/Next.md
+++ b/website/docs/advanced/Next.md
@@ -1,0 +1,85 @@
+---
+id: next
+title: Next storage implementation
+sidebar_label: Next storage implementation
+---
+import PlatformSupport from "../../src/components/Platform.js"
+
+**Supported platforms:**
+<PlatformSupport title="Android" platformIcon="icon_android.svg"></PlatformSupport>
+
+---
+
+### Motivation
+
+Current implementation of persistence layer is created using [SQLiteOpenHelper](https://developer.android.com/reference/android/database/sqlite/SQLiteOpenHelper), 
+a helper class that manages database creation and migrations. Even if this approach is powerful, the lack of compile time query verification and a big boilerplate of mapping SQLite queries  to actual values make this implementation prone to many errors.
+
+This Async Storage feature improves the persistence layer, using modern approaches to access SQLite (using [Room](https://developer.android.com/training/data-storage/room)), to reduce possible anomalies to the minimum. 
+On top of that, it allows to access Async Storage from the native side, useful in [Brownfield integration.](BrownfieldIntegration.md#android)
+
+### Migration
+
+This feature requires no migration from the developer perspective - the current database will be recreated (based on the current one), meaning user won't lose any data if you decide to opt in.
+There's a small drawback to know - the database "recreation" happens **only once**. Unless you want to disable the feature in the future, there's nothing to worry about.
+
+#### How it works
+
+The new database (the one used by this feature) will be created based on the current database file, if the new one does not exist yet. 
+If we detect that there's already the new database on the device, recreation will not kick in.
+
+
+#### Why is it important
+
+Let's say you enabled the feature for the first time - recreation kicks in and the old database file is untouched.
+If you decide to disable the feature, your users will be back using old database. No data migrations is happening from new to old database file.
+When you enable the feature again, the new database is **not** recreated, because it already exists, and no data is copied over.
+
+
+### Enabling
+
+1. In your project's `android` directory, locate root `build.gradle` file. Add Kotlin dependency to the `buildscript`:
+
+```diff
+buildscript {
+    ext {
+        // other extensions
++        kotlinVersion = '1.4.21'
+    }
+    
+    dependencies {
+        // other dependencies
++        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
+    }
+}
+
+```
+
+2. In the same directory (normally `android`) locate `gradle.properties` file (if does not exists, create one) and add the line:
+
+```groovy
+AsyncStorage_useNextStorage=true
+```
+
+**How to specifying Kotlin version**
+
+Supported Kotlin versions are `1.4.x`. You can specify which one to use in two ways:
+
+- having an `kotlinVersion` extension on the `rootProject` (recommended):
+
+```groovy
+rootProject.ext.kotlinVersion = '1.4.21'
+```
+
+- specify `AsyncStorage_kotlinVersion` in `gradle.properties`:
+
+```groovy
+AsyncStorage_kotlinVersion=1.4.21
+```
+
+### Notable changes
+
+Alongside of a warning regarding `key`/`value`, errors are thrown when:
+
+- Your `key` is `null` or `not a string`
+- You provide value that is `not a string` 

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -1,7 +1,7 @@
 module.exports = {
   docs: {
     'Getting started': ['install', 'usage', 'link', 'api'],
-    Advanced: ['advanced/jest', 'advanced/brownfield', 'advanced/backup', 'advanced/executor', 'advanced/db_size'],
+    Advanced: ['advanced/next', 'advanced/jest', 'advanced/brownfield', 'advanced/backup', 'advanced/executor', 'advanced/db_size'],
     Help: ['help/troubleshooting'],
   },
 };


### PR DESCRIPTION
## Summary

Current implementation of Sqlite access is cumbersome, error prone and produces [some](https://github.com/react-native-async-storage/async-storage/issues/498) hard to reproduce [errors](https://github.com/react-native-async-storage/async-storage/issues/355) to users. This PR aims to improve our native implementation of SQLite access and thread control. 


### About

This PR introduced the "next" storage implementation. [Room](https://developer.android.com/training/data-storage/room) has been used for database access, and [Coroutines](https://kotlinlang.org/docs/coroutines-overview.html) to handle asynchronous work.

I tried to reuse old database file, but due to it having a SQLite bug (where `primary key` can be null, which is a SQLite violation that Room is guarded against) I had to provide a migration path to copy over values to new database. This operation is done only once, the very first time feature is switched on.

**No developer migration is necessary to start using this feature**. It means that, once switched on, the same data stored so far will be available to use. No API change on JS side is involved. One notable change that can be somehow breaking is how this feature handle AsyncStorage rules violation - if `key` used is not string (or null) OR `value` is not a string, then error with proper message is thrown. No more cryptic sqlite errors.

As part of this PR and feature, some new enhancement:

- Updated the docs, to describe usage of the feature and also added an Android section to Brownfield integration doc, to show how one can access storage from native side.
- added new section in test app, called Basic, to test all basic test for AsyncStorage (get/set/remove, merge, getKeys, clearing db and error validation)
- added native unit tests to validate Storage access (since it can be used from native side as well).


### Test plan

Green CI, manual test on the Example App.