### PR TITLE
fix: add react 17 to peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,8 +60,8 @@
     "test:e2e:macos": "scripts/macos_e2e.sh 'test'"
   },
   "peerDependencies": {
-    "react": "^16.8",
-    "react-native": ">=0.59"
+    "react": "~16.8.6 || ~16.9.0 || ~16.11.0 || ~16.13.1 || ~17.0.1",
+    "react-native": "^0.60.6 || ^0.61.5 || ^0.62.2 || ^0.63.2 || ^0.64.0 || 1000.0.0"
   },
   "dependencies": {
     "deep-assign": "^3.0.0"


### PR DESCRIPTION
## Summary

Our React version requirement needs to match what react-native depends
on. Changing it to specific versions rather than a blanket 16.x or 17.x
to make sure that we stay compatible.

Resolves #535.

## Test Plan

No tests needed. CI should pass.