### PR TITLE
fix: Expo fallback function exporting

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -314,13 +314,14 @@ workflows:
           requires:
             - "Test: lint"
             - "Test: flow"
-      - "Release":
-          requires:
-            - "Test: iOS e2e"
-            - "Build: Android release apk"
-          filters:
-            branches:
-              only: master
       - "Test: Android e2e":
           requires:
             - "Build: Android release apk"
+      - "Release":
+          requires:
+            - "Test: iOS e2e"
+            - "Test: Android e2e"
+          filters:
+            branches:
+              only: master
+

--- a/src/shouldFallbackToLegacyNativeModule.js
+++ b/src/shouldFallbackToLegacyNativeModule.js
@@ -1,6 +1,6 @@
 const {NativeModules} = require('react-native');
 
-export default function shouldFallbackToLegacyNativeModule() {
+module.exports = function shouldFallbackToLegacyNativeModule() {
   const expoConstants =
     NativeModules.NativeUnimoduleProxy?.modulesConstants?.ExponentConstants;
 
@@ -27,4 +27,4 @@ export default function shouldFallbackToLegacyNativeModule() {
   }
 
   return false;
-}
+};


### PR DESCRIPTION
## Summary

Fixing the export for Expo fallback method, preventing from using Async Storage.
Also, releases should be done after all e2e passed.

## Test Plan

Green CI.
