### PR TITLE
Created Android scoped storage migration method

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/asyncstorage/AsyncStorageExpoMigration.java
+++ b/android/src/main/java/com/reactnativecommunity/asyncstorage/AsyncStorageExpoMigration.java
@@ -6,8 +6,6 @@ import android.util.Log;
 
 import androidx.annotation.RequiresApi;
 
-import com.facebook.react.modules.storage.ReactDatabaseSupplier;
-
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;

--- a/android/src/main/java/com/reactnativecommunity/asyncstorage/AsyncStorageExpoMigration.java
+++ b/android/src/main/java/com/reactnativecommunity/asyncstorage/AsyncStorageExpoMigration.java
@@ -19,7 +19,7 @@ import java.util.ArrayList;
 
 // A utility class that migrates a scoped AsyncStorage database to RKStorage.
 // This utility only runs if the RKStorage file has not been created yet.
-public class AsyncStorageMigration {
+public class AsyncStorageExpoMigration {
     static final String LOG_TAG = "AsyncStorageExpoMigration";
 
     public static void migrate(Context context) {

--- a/android/src/main/java/com/reactnativecommunity/asyncstorage/AsyncStorageMigration.java
+++ b/android/src/main/java/com/reactnativecommunity/asyncstorage/AsyncStorageMigration.java
@@ -1,0 +1,160 @@
+package com.reactnativecommunity.asyncstorage;
+
+import android.content.Context;
+import android.os.Build;
+import android.util.Log;
+
+import androidx.annotation.RequiresApi;
+
+import com.facebook.react.modules.storage.ReactDatabaseSupplier;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.channels.FileChannel;
+import java.nio.file.Files;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayList;
+
+// A utility class that migrates a scoped AsyncStorage database to RKStorage.
+// This utility only runs if the RKStorage file has not been created yet.
+public class AsyncStorageMigration {
+    static final String LOG_TAG = "ScopedStorageMigration";
+
+    private static Context mContext;
+
+    public static void migrate(Context context) {
+        mContext = context;
+
+        // Only migrate if the default async storage file does not exist.
+        if (isAsyncStorageDatabaseCreated()) {
+            return;
+        }
+
+        ArrayList<File> expoDatabases = getExpoDatabases();
+
+        File expoDatabase = getLastModifiedFile(expoDatabases);
+
+        if (expoDatabase == null) {
+            Log.v(LOG_TAG, "No scoped database found");
+            return;
+        }
+
+        try {
+            // Create the storage file
+            ReactDatabaseSupplier.getInstance(mContext).get();
+            copyFile(new FileInputStream(expoDatabase), new FileOutputStream(mContext.getDatabasePath(ReactDatabaseSupplier.DATABASE_NAME)));
+        } catch (Exception e) {
+            Log.v(LOG_TAG, "Failed to move scoped database");
+            e.printStackTrace();
+            return;
+        }
+
+        try {
+            for (File file : expoDatabases) {
+                if (file.delete()) {
+                    Log.v(LOG_TAG, "Deleted scoped database " + file.getName());
+                } else {
+                    Log.v(LOG_TAG, "Failed to delete scoped database " + file.getName());
+                }
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+
+        Log.v(LOG_TAG, "Completed the scoped AsyncStorage migration");
+    }
+
+    private static boolean isAsyncStorageDatabaseCreated() {
+        return mContext.getDatabasePath(ReactDatabaseSupplier.DATABASE_NAME).exists();
+    }
+
+    // Find all database files that the user may have created while using Expo.
+    private static ArrayList<File> getExpoDatabases() {
+        ArrayList<File> scopedDatabases = new ArrayList<>();
+        try {
+            File databaseDirectory = mContext.getDatabasePath("noop").getParentFile();
+            File[] directoryListing = databaseDirectory.listFiles();
+            if (directoryListing != null) {
+                for (File child : directoryListing) {
+                    // Find all databases matching the Expo scoped key, and skip any database journals.
+                    if (child.getName().startsWith("RKStorage-scoped-experience-") && !child.getName().endsWith("-journal")) {
+                        scopedDatabases.add(child);
+                    }
+                }
+            }
+        } catch (Exception e) {
+            // Just in case anything happens catch and print, file system rules can tend to be different across vendors.
+            e.printStackTrace();
+        }
+        return scopedDatabases;
+    }
+
+    // Returns the most recently modified file.
+    // If a user publishes an app with Expo, then changes the slug 
+    // and publishes again, a new database will be created. 
+    // We want to select the most recent database and migrate it to RKStorage.
+    private static File getLastModifiedFile(ArrayList<File> files) {
+        if (files.size() == 0) {
+            return null;
+        }
+        long lastMod = -1;
+        File lastModFile = null;
+        for (File child : files) {
+            long modTime = getLastModifiedTimeInMillis(child);
+            if (modTime > lastMod) {
+                lastMod = modTime;
+                lastModFile = child;
+            }
+        }
+        if (lastModFile != null) {
+            return lastModFile;
+        }
+
+        return files.get(0);
+    }
+
+    private static long getLastModifiedTimeInMillis(File file) {
+        try {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                return getLastModifiedTimeFromBasicFileAttrs(file);
+            } else {
+                return file.lastModified();
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+            return -1;
+        }
+    }
+
+    @RequiresApi(Build.VERSION_CODES.O)
+    private static long getLastModifiedTimeFromBasicFileAttrs(File file) {
+        try {
+            BasicFileAttributes attr = Files.readAttributes(file.toPath(), BasicFileAttributes.class);
+            return attr.creationTime().toMillis();
+        } catch (Exception e) {
+            return -1;
+        }
+    }
+
+    private static void copyFile(FileInputStream fromFile, FileOutputStream toFile) throws IOException {
+        FileChannel fromChannel = null;
+        FileChannel toChannel = null;
+        try {
+            fromChannel = fromFile.getChannel();
+            toChannel = toFile.getChannel();
+            fromChannel.transferTo(0, fromChannel.size(), toChannel);
+        } finally {
+            try {
+                if (fromChannel != null) {
+                    fromChannel.close();
+                }
+            } finally {
+                if (toChannel != null) {
+                    toChannel.close();
+                }
+            }
+        }
+    }
+}

--- a/android/src/main/java/com/reactnativecommunity/asyncstorage/AsyncStorageMigration.java
+++ b/android/src/main/java/com/reactnativecommunity/asyncstorage/AsyncStorageMigration.java
@@ -20,7 +20,7 @@ import java.util.ArrayList;
 // A utility class that migrates a scoped AsyncStorage database to RKStorage.
 // This utility only runs if the RKStorage file has not been created yet.
 public class AsyncStorageMigration {
-    static final String LOG_TAG = "ScopedStorageMigration";
+    static final String LOG_TAG = "AsyncStorageExpoMigration";
 
     public static void migrate(Context context) {
         // Only migrate if the default async storage file does not exist.

--- a/android/src/main/java/com/reactnativecommunity/asyncstorage/AsyncStorageMigration.java
+++ b/android/src/main/java/com/reactnativecommunity/asyncstorage/AsyncStorageMigration.java
@@ -22,17 +22,13 @@ import java.util.ArrayList;
 public class AsyncStorageMigration {
     static final String LOG_TAG = "ScopedStorageMigration";
 
-    private static Context mContext;
-
     public static void migrate(Context context) {
-        mContext = context;
-
         // Only migrate if the default async storage file does not exist.
-        if (isAsyncStorageDatabaseCreated()) {
+        if (isAsyncStorageDatabaseCreated(context)) {
             return;
         }
 
-        ArrayList<File> expoDatabases = getExpoDatabases();
+        ArrayList<File> expoDatabases = getExpoDatabases(context);
 
         File expoDatabase = getLastModifiedFile(expoDatabases);
 
@@ -43,8 +39,8 @@ public class AsyncStorageMigration {
 
         try {
             // Create the storage file
-            ReactDatabaseSupplier.getInstance(mContext).get();
-            copyFile(new FileInputStream(expoDatabase), new FileOutputStream(mContext.getDatabasePath(ReactDatabaseSupplier.DATABASE_NAME)));
+            ReactDatabaseSupplier.getInstance(context).get();
+            copyFile(new FileInputStream(expoDatabase), new FileOutputStream(context.getDatabasePath(ReactDatabaseSupplier.DATABASE_NAME)));
             Log.v(LOG_TAG, "Migrated most recently modified database " + expoDatabase.getName() + " to RKStorage");
         } catch (Exception e) {
             Log.v(LOG_TAG, "Failed to migrate scoped database " + expoDatabase.getName());
@@ -67,15 +63,15 @@ public class AsyncStorageMigration {
         Log.v(LOG_TAG, "Completed the scoped AsyncStorage migration");
     }
 
-    private static boolean isAsyncStorageDatabaseCreated() {
-        return mContext.getDatabasePath(ReactDatabaseSupplier.DATABASE_NAME).exists();
+    private static boolean isAsyncStorageDatabaseCreated(Context context) {
+        return context.getDatabasePath(ReactDatabaseSupplier.DATABASE_NAME).exists();
     }
 
     // Find all database files that the user may have created while using Expo.
-    private static ArrayList<File> getExpoDatabases() {
+    private static ArrayList<File> getExpoDatabases(Context context) {
         ArrayList<File> scopedDatabases = new ArrayList<>();
         try {
-            File databaseDirectory = mContext.getDatabasePath("noop").getParentFile();
+            File databaseDirectory = context.getDatabasePath("noop").getParentFile();
             File[] directoryListing = databaseDirectory.listFiles();
             if (directoryListing != null) {
                 for (File child : directoryListing) {

--- a/android/src/main/java/com/reactnativecommunity/asyncstorage/AsyncStorageMigration.java
+++ b/android/src/main/java/com/reactnativecommunity/asyncstorage/AsyncStorageMigration.java
@@ -128,8 +128,7 @@ public class AsyncStorageMigration {
     @RequiresApi(Build.VERSION_CODES.O)
     private static long getLastModifiedTimeFromBasicFileAttrs(File file) {
         try {
-            BasicFileAttributes attr = Files.readAttributes(file.toPath(), BasicFileAttributes.class);
-            return attr.creationTime().toMillis();
+            return Files.readAttributes(file.toPath(), BasicFileAttributes.class).creationTime().toMillis();
         } catch (Exception e) {
             return -1;
         }

--- a/android/src/main/java/com/reactnativecommunity/asyncstorage/AsyncStorageMigration.java
+++ b/android/src/main/java/com/reactnativecommunity/asyncstorage/AsyncStorageMigration.java
@@ -52,18 +52,6 @@ public class AsyncStorageMigration {
             return;
         }
 
-        try {
-            for (File file : expoDatabases) {
-                if (file.delete()) {
-                    Log.v(LOG_TAG, "Deleted scoped database " + file.getName());
-                } else {
-                    Log.v(LOG_TAG, "Failed to delete scoped database " + file.getName());
-                }
-            }
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
-
         Log.v(LOG_TAG, "Completed the scoped AsyncStorage migration");
     }
 

--- a/android/src/main/java/com/reactnativecommunity/asyncstorage/AsyncStorageMigration.java
+++ b/android/src/main/java/com/reactnativecommunity/asyncstorage/AsyncStorageMigration.java
@@ -52,6 +52,18 @@ public class AsyncStorageMigration {
             return;
         }
 
+        try {
+            for (File file : expoDatabases) {
+                if (file.delete()) {
+                    Log.v(LOG_TAG, "Deleted scoped database " + file.getName());
+                } else {
+                    Log.v(LOG_TAG, "Failed to delete scoped database " + file.getName());
+                }
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+
         Log.v(LOG_TAG, "Completed the scoped AsyncStorage migration");
     }
 

--- a/android/src/main/java/com/reactnativecommunity/asyncstorage/AsyncStorageMigration.java
+++ b/android/src/main/java/com/reactnativecommunity/asyncstorage/AsyncStorageMigration.java
@@ -45,8 +45,9 @@ public class AsyncStorageMigration {
             // Create the storage file
             ReactDatabaseSupplier.getInstance(mContext).get();
             copyFile(new FileInputStream(expoDatabase), new FileOutputStream(mContext.getDatabasePath(ReactDatabaseSupplier.DATABASE_NAME)));
+            Log.v(LOG_TAG, "Migrated most recently modified database " + expoDatabase.getName() + " to RKStorage");
         } catch (Exception e) {
-            Log.v(LOG_TAG, "Failed to move scoped database");
+            Log.v(LOG_TAG, "Failed to migrate scoped database " + expoDatabase.getName());
             e.printStackTrace();
             return;
         }

--- a/android/src/main/java/com/reactnativecommunity/asyncstorage/AsyncStorageModule.java
+++ b/android/src/main/java/com/reactnativecommunity/asyncstorage/AsyncStorageModule.java
@@ -91,8 +91,12 @@ public final class AsyncStorageModule
   @VisibleForTesting
   AsyncStorageModule(ReactApplicationContext reactContext, Executor executor) {
     super(reactContext);
+    // The migration MUST run before the AsyncStorage database is created for the first time.
+    AsyncStorageMigration.migrate(reactContext);
+
     this.executor = new SerialExecutor(executor);
     reactContext.addLifecycleEventListener(this);
+    // Creating the database MUST happen after the migration.
     mReactDatabaseSupplier = ReactDatabaseSupplier.getInstance(reactContext);
   }
 

--- a/android/src/main/java/com/reactnativecommunity/asyncstorage/AsyncStorageModule.java
+++ b/android/src/main/java/com/reactnativecommunity/asyncstorage/AsyncStorageModule.java
@@ -92,7 +92,7 @@ public final class AsyncStorageModule
   AsyncStorageModule(ReactApplicationContext reactContext, Executor executor) {
     super(reactContext);
     // The migration MUST run before the AsyncStorage database is created for the first time.
-    AsyncStorageMigration.migrate(reactContext);
+    AsyncStorageExpoMigration.migrate(reactContext);
 
     this.executor = new SerialExecutor(executor);
     reactContext.addLifecycleEventListener(this);


### PR DESCRIPTION
## Summary

Expo users who publish an app with `expo build:android` will use a database file like `RKStorage-scoped-experience- <encoded-project-slug>` when they eject, the 
database file will be `RKStorage`, this effectively prevents many users from being able to eject https://github.com/expo/expo/issues/8220 and use this package.

This PR introduces parity for an [iOS feature](https://github.com/react-native-async-storage/async-storage/blob/af0677c43e5087404b0def0dd084a69e1930cbf5/ios/RNCAsyncStorage.m#L395-L399) that migrates the database directory.

1. Check to see if `RKStorage` file exists (if not bail out).
2. Query all files in the database directory starting with `RKStorage-scoped-experience-`
3. Get the most recently modified file to migrate. This is useful because users who change their slug and republish may have multiple database files and they'll want to use the most recent one.
4. Copy the contents of this file to `RKStorage`
5. Delete all of the scoped database files. This creates parity with iOS.

## Test Plan

Testing this feature is a little _involved_.

### Managed -> Bare

0. Delete the app -- effectively deleting all of it's data and the `RKStorage` file.
1. Comment out the line `AsyncStorageMigration.migrate(reactContext);`
2. Change ["RKStorage"](https://github.com/react-native-async-storage/async-storage/blob/87805694cc8ee07c594ef4c8f56caf4163acb498/android/src/main/java/com/reactnativecommunity/asyncstorage/ReactDatabaseSupplier.java#L25) to something like `RKStorage-scoped-experience-foobar-1`
3. Build the app, make a few modifications.
4. Repeat the last two steps with a new storage name (`RKStorage-scoped-experience-foobar-2`) -- This is to test that the most recent slug gets used.
5. Uncomment the line `AsyncStorageMigration.migrate(reactContext);` and change the database name back to `RKStorage`.
6. Build the app, you'll notice the logs print out info about the migration (ScopedStorageMigration log tag). The AsyncStorage in-app should have changed to match the most recent modifications from `RKStorage-scoped-experience-foobar-2`.
7. Reload the app, you should see no longs related to the migration.


### Bare only

0. Delete the app -- effectively deleting all of it's data and the `RKStorage` file.
1. Build the app, you should see a log "No scoped database found" -- This is what users who run `AsyncStorage` for the first time without ever using Expo will see.
2. Reload the app and there should be no logs related to the migration.

