### PR TITLE
Migrate Expo storage directory on iOS

### DIFF
--- a/ios/RNCAsyncStorage.m
+++ b/ios/RNCAsyncStorage.m
@@ -16,6 +16,7 @@
 
 static NSString *const RCTStorageDirectory = @"RCTAsyncLocalStorage_V1";
 static NSString *const RCTOldStorageDirectory = @"RNCAsyncLocalStorage_V1";
+static NSString *const RCTExpoStorageDirectory = @"RCTAsyncLocalStorage";
 static NSString *const RCTManifestFileName = @"manifest.json";
 static const NSUInteger RCTInlineValueThreshold = 1024;
 
@@ -389,6 +390,13 @@ RCTStorageDirectoryMigrationCheck(NSString *fromStorageDirectory,
     // "Documents/.../RCTAsyncLocalStorage_V1"
     RCTStorageDirectoryMigrationCheck(
         RCTCreateStorageDirectoryPath_deprecated(RCTOldStorageDirectory),
+        RCTCreateStorageDirectoryPath_deprecated(RCTStorageDirectory),
+        YES);
+
+    // Alternatively, migrate Expo's managed app path "Documents/.../RNCAsyncLocalStorage" to
+    // "Documents/.../RCTAsyncLocalStorage_V1"
+    RCTStorageDirectoryMigrationCheck(
+        RCTCreateStorageDirectoryPath_deprecated(RCTExpoStorageDirectory),
         RCTCreateStorageDirectoryPath_deprecated(RCTStorageDirectory),
         YES);
 

--- a/ios/RNCAsyncStorage.m
+++ b/ios/RNCAsyncStorage.m
@@ -430,19 +430,19 @@ RCTStorageDirectoryMigrationCheck(NSString *fromStorageDirectory,
     // the oldest are removed and the most recently modified is returned.
     NSString *oldStoragePath = RCTGetStoragePathForMigration();
     if (oldStoragePath != nil) {
-        // First migrate our deprecated path "Documents/.../RNCAsyncLocalStorage_V1" or
+        // Migrate our deprecated path "Documents/.../RNCAsyncLocalStorage_V1" or
         // "Documents/.../RCTsyncLocalStorage" to "Documents/.../RCTAsyncLocalStorage_V1"
         RCTStorageDirectoryMigrationCheck(
             oldStoragePath,
             RCTCreateStorageDirectoryPath_deprecated(RCTStorageDirectory),
             YES);
-
-        // Then migrate what's in "Documents/.../RCTAsyncLocalStorage_V1" to "Application
-        // Support/[bundleID]/RCTAsyncLocalStorage_V1"
-        RCTStorageDirectoryMigrationCheck(RCTCreateStorageDirectoryPath_deprecated(RCTStorageDirectory),
-                                          RCTCreateStorageDirectoryPath(RCTStorageDirectory),
-                                          NO);
     }
+
+    // Migrate what's in "Documents/.../RCTAsyncLocalStorage_V1" to
+    // "Application Support/[bundleID]/RCTAsyncLocalStorage_V1"
+    RCTStorageDirectoryMigrationCheck(RCTCreateStorageDirectoryPath_deprecated(RCTStorageDirectory),
+                                      RCTCreateStorageDirectoryPath(RCTStorageDirectory),
+                                      NO);
 
     return self;
 }

--- a/ios/RNCAsyncStorage.m
+++ b/ios/RNCAsyncStorage.m
@@ -316,6 +316,46 @@ static void RCTStorageDirectoryMigrate(NSString *oldDirectoryPath,
     }
 }
 
+
+/**
+ * Determine which of RCTOldStorageDirectory or RCTExpoStorageDirectory needs to migrated.
+ * If both exist, we remove the least recently modified and return the most recently modified.
+ * Otherwise, this will return the path to whichever directory exists.
+ * If no directory exists, then return nil.
+ */
+static NSString *RCTGetStoragePathForMigration()
+{
+    BOOL isDir;
+    NSString *oldStoragePath = RCTCreateStorageDirectoryPath_deprecated(RCTOldStorageDirectory);
+    NSString *expoStoragePath = RCTCreateStorageDirectoryPath_deprecated(RCTExpoStorageDirectory);
+    NSFileManager *fileManager = [NSFileManager defaultManager];
+    BOOL oldStorageDirectoryExists = [fileManager fileExistsAtPath:oldStoragePath isDirectory:&isDir] && isDir;
+    BOOL expoStorageDirectoryExists = [fileManager fileExistsAtPath:expoStoragePath isDirectory:&isDir] && isDir;
+
+
+    // Check if both the old storage directory and Expo storage directory exist
+    if (oldStorageDirectoryExists && expoStorageDirectoryExists) {
+        // If the old storage has been modified more recently than Expo storage, then clear Expo storage.
+        // Otherwise, clear the old storage.
+        if ([RCTManifestModificationDate(RCTCreateManifestFilePath(oldStoragePath))
+                compare:RCTManifestModificationDate(
+                            RCTCreateManifestFilePath(expoStoragePath))] == NSOrderedDescending) {
+            RCTStorageDirectoryCleanupOld(expoStoragePath);
+            return oldStoragePath;
+        } else {
+            RCTStorageDirectoryCleanupOld(oldStoragePath);
+            return expoStoragePath;
+        }
+    } else if (oldStorageDirectoryExists) {
+        return oldStoragePath;
+    } else if (expoStorageDirectoryExists) {
+        return expoStoragePath;
+    } else {
+        return nil;
+    }
+}
+
+
 /**
  * This check is added to make sure that anyone coming from pre-1.2.2 does not lose cached data.
  * Check that data is migrated from the old location to the new location
@@ -386,25 +426,23 @@ RCTStorageDirectoryMigrationCheck(NSString *fromStorageDirectory,
         return nil;
     }
 
-    // First migrate our deprecated path "Documents/.../RNCAsyncLocalStorage_V1" to
-    // "Documents/.../RCTAsyncLocalStorage_V1"
-    RCTStorageDirectoryMigrationCheck(
-        RCTCreateStorageDirectoryPath_deprecated(RCTOldStorageDirectory),
-        RCTCreateStorageDirectoryPath_deprecated(RCTStorageDirectory),
-        YES);
+    // Get the path to any old storage directory that needs to be migrated. If multiple exist,
+    // the oldest are removed and the most recently modified is returned.
+    NSString *oldStoragePath = RCTGetStoragePathForMigration();
+    if (oldStoragePath != nil) {
+        // First migrate our deprecated path "Documents/.../RNCAsyncLocalStorage_V1" or
+        // "Documents/.../RCTsyncLocalStorage" to "Documents/.../RCTAsyncLocalStorage_V1"
+        RCTStorageDirectoryMigrationCheck(
+            oldStoragePath,
+            RCTCreateStorageDirectoryPath_deprecated(RCTStorageDirectory),
+            YES);
 
-    // Alternatively, migrate Expo's managed app path "Documents/.../RNCAsyncLocalStorage" to
-    // "Documents/.../RCTAsyncLocalStorage_V1"
-    RCTStorageDirectoryMigrationCheck(
-        RCTCreateStorageDirectoryPath_deprecated(RCTExpoStorageDirectory),
-        RCTCreateStorageDirectoryPath_deprecated(RCTStorageDirectory),
-        YES);
-
-    // Then migrate what's in "Documents/.../RCTAsyncLocalStorage_V1" to "Application
-    // Support/[bundleID]/RCTAsyncLocalStorage_V1"
-    RCTStorageDirectoryMigrationCheck(RCTCreateStorageDirectoryPath_deprecated(RCTStorageDirectory),
-                                      RCTCreateStorageDirectoryPath(RCTStorageDirectory),
-                                      NO);
+        // Then migrate what's in "Documents/.../RCTAsyncLocalStorage_V1" to "Application
+        // Support/[bundleID]/RCTAsyncLocalStorage_V1"
+        RCTStorageDirectoryMigrationCheck(RCTCreateStorageDirectoryPath_deprecated(RCTStorageDirectory),
+                                          RCTCreateStorageDirectoryPath(RCTStorageDirectory),
+                                          NO);
+    }
 
     return self;
 }

--- a/ios/RNCAsyncStorage.m
+++ b/ios/RNCAsyncStorage.m
@@ -431,7 +431,7 @@ RCTStorageDirectoryMigrationCheck(NSString *fromStorageDirectory,
     NSString *oldStoragePath = RCTGetStoragePathForMigration();
     if (oldStoragePath != nil) {
         // Migrate our deprecated path "Documents/.../RNCAsyncLocalStorage_V1" or
-        // "Documents/.../RCTsyncLocalStorage" to "Documents/.../RCTAsyncLocalStorage_V1"
+        // "Documents/.../RCTAsyncLocalStorage" to "Documents/.../RCTAsyncLocalStorage_V1"
         RCTStorageDirectoryMigrationCheck(
             oldStoragePath,
             RCTCreateStorageDirectoryPath_deprecated(RCTStorageDirectory),


### PR DESCRIPTION
## Summary

This solves [an issue](https://github.com/expo/expo/issues/8220) users encountered with the following process:
- build app with managed workflow, submit to store, users use it, data saved to RCTAsyncLocalStorage.
- eject app, build and resubmit, users update app and now @react-native-async-storage/async-storage native module is linked and it looks for data in RCTAsyncLocalStorage_V1, no data found - resulting in data loss.

Something that I noticed while implementing this was that it is theoretically possible (although extremely unlikely) that a user would have both an old storage directory and an Expo storage directory ("RNCAsyncLocalStorage_V1" and "RCTAsyncLocalStorage"). To handle this case, I added `RCTGetStoragePathForMigration`.

The Android side of this migration is handled in #559

## Test Plan

- Created a managed Expo app: I created a simple app to test this: [App.tsx](https://gist.github.com/brentvatne/148d6a8ad36989b5d1d21f1149ece917). (`expo init` with managed Typescript template, `expo install @react-native-async-storage/async-storage`, then added that code to App.tsx).
- Built it with managed workflow: `expo build:ios -t simulator` (it takes about 2 minutes to build, you can access the binary [here](https://exp-shell-app-assets.s3.us-west-1.amazonaws.com/ios/%40notbrent/testing-storage-54d9306a-61e3-4598-956d-b9bb1e75a6b5-simulator.tar.gz) for the next ~28 days).
- Ran the app in simulator, pressed button to increment value a few times.
- Ran `expo eject`, applied the patch from this PR to my local copy of `RNCAsyncStorage.m`, then built the project and ran it on the same simulator as the previous step.
- Observed that the storage directory was migrated successfully - the count remained the same.

Here's a video quick run through the above test plan, skipping the steps that could be done in advance: 


https://user-images.githubusercontent.com/90494/111529100-01458000-871f-11eb-9428-54bde3f0da0e.mp4

(I added !! after the count to make it especially clear that this is a different build)
