### PR TITLE
feat: add exception when array is passed for 2nd arg

### DIFF
--- a/src/AsyncStorage.native.js
+++ b/src/AsyncStorage.native.js
@@ -69,6 +69,14 @@ function checkValidInput(usedKey: string, value: any) {
   }
 }
 
+function checkValidArgs(args: Array<Array<string>>) {
+  if (Array.isArray(args[1])) {
+    throw new Error(
+      '[AsyncStorage] Did you mean to pass an array of key value pairs instead? The second arguement to multiSet cannot be an array\n',
+    );
+  }
+}
+
 /**
  * `AsyncStorage` is a simple, unencrypted, asynchronous, persistent, key-value
  * storage system that is global to the app.  It should be used instead of
@@ -322,6 +330,7 @@ const AsyncStorage = {
     callback?: ?(errors: ?$ReadOnlyArray<?Error>) => void,
   ): Promise<null> {
     return new Promise((resolve, reject) => {
+      checkValidArgs(arguments);
       keyValuePairs.forEach(([key, value]) => {
         checkValidInput(key, value);
       });

--- a/src/AsyncStorage.native.js
+++ b/src/AsyncStorage.native.js
@@ -69,10 +69,26 @@ function checkValidInput(usedKey: string, value: any) {
   }
 }
 
-function checkValidArgs(args: Array<Array<string>>) {
-  if (Array.isArray(args[1])) {
+function checkValidArgs(keyValuePairs, callback) {
+  if (
+    !Array.isArray(keyValuePairs) ||
+    keyValuePairs.length === 0 ||
+    !Array.isArray(keyValuePairs[0])
+  ) {
     throw new Error(
-      '[AsyncStorage] Did you mean to pass an array of key value pairs instead? The second arguement to multiSet cannot be an array\n',
+      '[AsyncStorage] Expected array of key-value pairs as first argument to multiSet',
+    );
+  }
+
+  if (callback && typeof callback !== 'function') {
+    if (Array.isArray(callback)) {
+      throw new Error(
+        '[AsyncStorage] Expected function as second argument to multiSet. Did you forget to wrap key-value pairs in an array for the first argument?',
+      );
+    }
+
+    throw new Error(
+      '[AsyncStorage] Expected function as second argument to multiSet',
     );
   }
 }
@@ -329,8 +345,8 @@ const AsyncStorage = {
     keyValuePairs: Array<Array<string>>,
     callback?: ?(errors: ?$ReadOnlyArray<?Error>) => void,
   ): Promise<null> {
+    checkValidArgs(keyValuePairs, callback);
     return new Promise((resolve, reject) => {
-      checkValidArgs(arguments);
       keyValuePairs.forEach(([key, value]) => {
         checkValidInput(key, value);
       });


### PR DESCRIPTION
- For cases when two or more key values pairs are passed unintentionally as arguements to multiSet.



## Summary
resolves #519
<!--
  Thank you for submitting a PR!

  Help us understand more of your work - you can explain what you did, post a
  link to an issue, screenshots etc. Anything helps!
-->

## Test Plan
As I ran and went through the e2e tests, observed that there are no tests aded for `multiSet` and `multiGet`. As this is an exception that is being added to `multiSet`, would not be ideal to create the tests for the same. 
<!--
    Help us test your work (**REQUIRED**).

    If you changed the code, please provide us with instructions of how we can
    try it out ourselves, so we can confirm it's working. You can also post
    screenshots/gifts.
-->
