### PR TITLE
Added testresults.gradle in bundle as it is required to install on android using next storage

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "types/",
     "android/src",
     "android/build.gradle",
+    "android/testresults.gradle",
     "ios/",
     "macos/",
     "windows/",


### PR DESCRIPTION
Install fails on android using next version because of [this line in build.gradle](https://github.com/react-native-async-storage/async-storage/blame/75c571b7b1265e7d5599e0b9e38e19acb6004181/android/build.gradle#L72) created by @Krizzu. It requires a file that is not included in the bundled async storage library.

```
FAILURE: Build completed with 2 failures.

1: Task failed with an exception.
-----------
* Where:
Build file '~/project/node_modules/@react-native-async-storage/async-storage/android/build.gradle' line: 72

* What went wrong:
A problem occurred evaluating project ':react-native-async-storage_async-storage'.
> Could not read script '~/project/node_modules/@react-native-async-storage/async-storage/android/testresults.gradle' as it does not exist.

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.
==============================================================================
```

<img width="627" alt="image" src="https://user-images.githubusercontent.com/671923/113449774-9659a180-93cc-11eb-879f-3c269e1e2a9b.png">


## Summary

<!--
  Thank you for submitting a PR!

  Help us understand more of your work - you can explain what you did, post a
  link to an issue, screenshots etc. Anything helps!
-->

## Test Plan

<!--
    Help us test your work (**REQUIRED**).

    If you changed the code, please provide us with instructions of how we can
    try it out ourselves, so we can confirm it's working. You can also post
    screenshots/gifts.
-->
