### PR TITLE
fix(next storage): Force SQLite checkpoint on Pie and up

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/asyncstorage/AsyncLocalStorageUtil.java
+++ b/android/src/main/java/com/reactnativecommunity/asyncstorage/AsyncLocalStorageUtil.java
@@ -8,11 +8,9 @@
 package com.reactnativecommunity.asyncstorage;
 
 import javax.annotation.Nullable;
-
 import java.io.File;
 import java.util.Arrays;
 import java.util.Iterator;
-
 import android.content.ContentValues;
 import android.content.Context;
 import android.database.Cursor;
@@ -20,12 +18,9 @@ import android.database.sqlite.SQLiteDatabase;
 import android.os.Build;
 import android.text.TextUtils;
 import android.util.Log;
-
 import com.facebook.react.bridge.ReadableArray;
-
 import org.json.JSONException;
 import org.json.JSONObject;
-
 import static com.reactnativecommunity.asyncstorage.ReactDatabaseSupplier.KEY_COLUMN;
 import static com.reactnativecommunity.asyncstorage.ReactDatabaseSupplier.TABLE_CATALYST;
 import static com.reactnativecommunity.asyncstorage.ReactDatabaseSupplier.VALUE_COLUMN;
@@ -159,7 +154,7 @@ public class AsyncLocalStorageUtil {
    * This helper will force checkpoint on RKStorage, if Next storage file does not exists yet.
    */
   public static void verifyAndForceSqliteCheckpoint(Context ctx) {
-    if(Build.VERSION.SDK_INT < Build.VERSION_CODES.P) {
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.P) {
         Log.i("AsyncStorage_Next", "SQLite checkpoint not required on this API version.");
     }
 

--- a/android/src/main/java/com/reactnativecommunity/asyncstorage/AsyncLocalStorageUtil.java
+++ b/android/src/main/java/com/reactnativecommunity/asyncstorage/AsyncLocalStorageUtil.java
@@ -9,13 +9,17 @@ package com.reactnativecommunity.asyncstorage;
 
 import javax.annotation.Nullable;
 
+import java.io.File;
 import java.util.Arrays;
 import java.util.Iterator;
 
 import android.content.ContentValues;
+import android.content.Context;
 import android.database.Cursor;
 import android.database.sqlite.SQLiteDatabase;
+import android.os.Build;
 import android.text.TextUtils;
+import android.util.Log;
 
 import com.facebook.react.bridge.ReadableArray;
 
@@ -140,6 +144,38 @@ public class AsyncLocalStorageUtil {
       } else {
         oldJSON.put(key, newJSON.get(key));
       }
+    }
+  }
+  /**
+   * From Pie and up, Android started to use Write-ahead logging (WAL), instead of journal rollback
+   * for atomic commits and rollbacks.
+   * Basically, WAL does not write directly to the database file, rather to the supporting WAL file.
+   * Because of that, migration to the next storage might not be successful, because the content of
+   * RKStorage might be still in WAL file instead. Committing all data from WAL to db file is called
+   * a "checkpoint" and is done automatically (by default) when the WAL file reaches a threshold
+   * size of 1000 pages.
+   * More here: https://sqlite.org/wal.html
+   * <p>
+   * This helper will force checkpoint on RKStorage, if Next storage file does not exists yet.
+   */
+  public static void verifyAndForceSqliteCheckpoint(Context ctx) {
+    File nextStorageFile = ctx.getDatabasePath("AsyncStorage");
+    File currentStorageFile = ctx.getDatabasePath(ReactDatabaseSupplier.DATABASE_NAME);
+    boolean isCheckpointRequired = Build.VERSION.SDK_INT >= Build.VERSION_CODES.P
+            && !nextStorageFile.exists()
+            && currentStorageFile.exists();
+    if (!isCheckpointRequired) {
+      Log.i("AsyncStorage_Next", "SQLite checkpoint not required.");
+      return;
+    }
+
+    try {
+      ReactDatabaseSupplier supplier = ReactDatabaseSupplier.getInstance(ctx);
+      supplier.get().execSQL("PRAGMA wal_checkpoint");
+      supplier.closeDatabase();
+      Log.i("AsyncStorage_Next", "Forcing SQLite checkpoint successful.");
+    } catch (Exception e) {
+      Log.w("AsyncStorage_Next", "Could not force checkpoint on RKStorage: " + e.getMessage());
     }
   }
 }

--- a/android/src/main/java/com/reactnativecommunity/asyncstorage/AsyncStoragePackage.java
+++ b/android/src/main/java/com/reactnativecommunity/asyncstorage/AsyncStoragePackage.java
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * <p>
+ *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
@@ -8,14 +8,12 @@
 package com.reactnativecommunity.asyncstorage;
 
 import android.util.Log;
-
 import com.facebook.react.ReactPackage;
 import com.facebook.react.bridge.JavaScriptModule;
 import com.facebook.react.bridge.NativeModule;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.uimanager.ViewManager;
-
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;

--- a/android/src/main/java/com/reactnativecommunity/asyncstorage/AsyncStoragePackage.java
+++ b/android/src/main/java/com/reactnativecommunity/asyncstorage/AsyncStoragePackage.java
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- *
+ * <p>
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
@@ -8,12 +8,14 @@
 package com.reactnativecommunity.asyncstorage;
 
 import android.util.Log;
+
 import com.facebook.react.ReactPackage;
 import com.facebook.react.bridge.JavaScriptModule;
 import com.facebook.react.bridge.NativeModule;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.uimanager.ViewManager;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -29,6 +31,7 @@ public class AsyncStoragePackage implements ReactPackage {
                 Class storageClass = Class.forName("com.reactnativecommunity.asyncstorage.next.StorageModule");
                 NativeModule inst = (NativeModule) storageClass.getDeclaredConstructor(new Class[]{ReactContext.class}).newInstance(reactContext);
                 moduleList.add(inst);
+                AsyncLocalStorageUtil.verifyAndForceSqliteCheckpoint(reactContext);
             } catch (Exception e) {
                 String message = "Something went wrong when initializing module:"
                         + "\n"

--- a/android/src/main/java/com/reactnativecommunity/asyncstorage/next/StorageSupplier.kt
+++ b/android/src/main/java/com/reactnativecommunity/asyncstorage/next/StorageSupplier.kt
@@ -1,6 +1,7 @@
 package com.reactnativecommunity.asyncstorage.next
 
 import android.content.Context
+import android.util.Log
 import androidx.room.ColumnInfo
 import androidx.room.Dao
 import androidx.room.Database
@@ -100,6 +101,7 @@ private object MIGRATION_TO_NEXT : Migration(1, 2) {
             FROM $oldTableName;
         """.trimIndent()
         )
+        Log.e("AsyncStorage_Next", "Migration to Next storage completed.")
     }
 }
 


### PR DESCRIPTION
## Summary

From Pie and up, Android started to use Write-ahead logging (WAL) by default, instead of journal rollback. WAL does not write directly to the database file, rather to the supporting WAL file. The content of WAL file is "flushed" to original DB file (this action is called a **checkpoint**), when page size threshold is reached (default is 1000).

Because of that, migration to Next storage might not be successful, because RKStorage database content might still be in WAL file (and Next AsyncStorage uses RKStorage file to rehydrate itself). This PR introduces a helper that will make sure we force **checkpoint**, to always have the latest content on db file, before migrating.


@EvanBacon I suspect we'd want the same thing happen for Expo migration as well?

