### PR TITLE
Expose the getAllKeys so that natively we can access all the keys

### DIFF
--- a/ios/RNCAsyncStorage.h
+++ b/ios/RNCAsyncStorage.h
@@ -45,4 +45,7 @@
 - (void)multiSet:(NSArray<NSArray<NSString *> *> *)kvPairs
         callback:(RCTResponseSenderBlock)callback;
 
+// Interface for natively fetching all the keys from the storage data.
+- (void)getAllKeys:(RCTResponseSenderBlock)callback;
+
 @end


### PR DESCRIPTION
In using a custom `RNCAsyncStorageDelegate` subclass to customized the storage of our data into a shared group container, we have needs to expose this method that is currently private (and exposed to ReactNative via a RCT_Export macro) to the header file.

Since we have past versions of our app that was not stored in the custom storage location, but rather the default location, we run some native migration logic when we first load RNAsyncStorage from RCTBridge to see if we need to migrate. We read out each value by key from the default storage and write those keys using our delegate backed instance and then removing from the default storage location.

It would be nice to simply expose this on the native side.

I've included the example export and import logic (in swift) we are using  for this:

``` swift  
extension RNCAsyncStorage {
  func exportKeyPairs() -> [[String]]? {
    
    var keyPairs: [[String]]? = nil
    
    methodQueue.sync {
      
      var allKeys: [String]?
      getAllKeys() { results in
        allKeys = results?[1] as? [String]
      }
      
      // Check if we have any keys that need to export. If we do not, keys would be a count of 0, or there was an
      // error fetching them
      guard let keys = allKeys, keys.count > 0 else {
        return
      }
       
      multiGet(keys) { results in
        let result = results?[1]
        keyPairs = result as? [[String]]
      }
    }
    
    NSLog("export keypairs: \(String(describing: keyPairs))")
    return keyPairs
  }
  
  func importKeyPairs(_ keyPairs: [[String]]) {
    methodQueue.sync {
      multiSet(keyPairs) { result in
        NSLog("import results: \(String(describing: result))")
      }
    }
  }
}
````