### PR TITLE
chore: add 'Close Stale Issues' workflow to clean up old issues

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,18 @@
+name: Mark stale issues and pull requests
+on:
+  schedule:
+  - cron: "30 1 * * *"
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+    - uses: actions/stale@v3
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-issue-message: 'This issue has been marked as stale due to inactivity. Please respond or otherwise resolve the issue within 7 days or it will be closed.'
+        stale-pr-message: 'This PR has been marked as stale due to inactivity. Please address any comments within 7 days or it will be closed.'
+        exempt-issue-labels: 'help wanted :octocat:'
+        exempt-pr-labels: 'WIP'


### PR DESCRIPTION
## Summary

Adds a workflow for cleaning up old issues. By the default, issues/prs are marked as stale after 60 days of inactivity, and closed 7 days after being marked. Issues are exempt if they are labeled `help wanted :octocat:` or `WIP`.

## Test Plan

There's currently no way to test this. It will have to be run over-night.