### PR TITLE
fix: replace deprecated deep-assign with lodash merge

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -4,5 +4,6 @@
   "trailingComma": "all",
   "bracketSpacing": false,
   "jsxBracketSameLine": true,
-  "parser": "flow"
+  "parser": "flow",
+  "endOfLine": "auto"
 }

--- a/jest/async-storage-mock.js
+++ b/jest/async-storage-mock.js
@@ -2,6 +2,8 @@
  * @format
  */
 
+import merge from 'lodash.merge';
+
 const asMock = {
   __INTERNAL_MOCK_STORAGE__: {},
 
@@ -95,31 +97,12 @@ async function _multiMerge(keyValuePairs, callback) {
     const oldValue = JSON.parse(asMock.__INTERNAL_MOCK_STORAGE__[key]);
 
     asMock.__INTERNAL_MOCK_STORAGE__[key] = JSON.stringify(
-      _deepMergeInto(oldValue, value),
+      merge(oldValue, value),
     );
   });
 
   callback && callback(null);
   return null;
 }
-
-const _isObject = (obj) => typeof obj === 'object' && !Array.isArray(obj);
-const _deepMergeInto = (oldObject, newObject) => {
-  const newKeys = Object.keys(newObject);
-  const mergedObject = oldObject;
-
-  newKeys.forEach((key) => {
-    const oldValue = mergedObject[key];
-    const newValue = newObject[key];
-
-    if (_isObject(oldValue) && _isObject(newValue)) {
-      mergedObject[key] = _deepMergeInto(oldValue, newValue);
-    } else {
-      mergedObject[key] = newValue;
-    }
-  });
-
-  return mergedObject;
-};
 
 module.exports = asMock;

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "test:e2e:macos": "scripts/macos_e2e.sh 'test'"
   },
   "dependencies": {
-    "deep-assign": "^3.0.0"
+    "lodash.merge": "^4.6.2"
   },
   "peerDependencies": {
     "react-native": "^0.60.6 || ^0.61.5 || ^0.62.2 || ^0.63.2 || ^0.64.0 || 1000.0.0"

--- a/src/AsyncStorage.js
+++ b/src/AsyncStorage.js
@@ -8,7 +8,7 @@
  * @flow
  */
 
-import merge from 'deep-assign';
+import merge from 'lodash.merge';
 
 const mergeLocalStorageItem = (key, value) => {
   const oldValue = window.localStorage.getItem(key);

--- a/yarn.lock
+++ b/yarn.lock
@@ -9745,6 +9745,11 @@ lodash.memoize@^4.1.2:
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
   integrity sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=
 
+lodash.merge@^4.6.2:
+  version "4.6.2"
+  resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
+  integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
+
 lodash.sortby@^4.7.0:
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
@@ -15436,8 +15441,10 @@ watchpack@^1.6.1:
   resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-1.7.5.tgz#1267e6c55e0b9b5be44c2023aed5437a2c26c453"
   integrity sha512-9P3MWk6SrKjHsGkLT2KHXdQ/9SNkyoJbabxnKOoJepsvJjJG8uYTR3yTPxPQvNDI3w4Nz1xnE0TLHK4RIVe/MQ==
   dependencies:
+    chokidar "^3.4.1"
     graceful-fs "^4.1.2"
     neo-async "^2.5.0"
+    watchpack-chokidar2 "^2.0.1"
   optionalDependencies:
     chokidar "^3.4.1"
     watchpack-chokidar2 "^2.0.1"


### PR DESCRIPTION
## Summary

Replace deep-assign with lodash.merge, as per #374. I understand it's better to use actively maintained packages because it's more likely people already have the package installed, and because if there are any security issues there's a better chance they'll be handled. I know 'if it ain't broke, don't fix it' but this also removes the deprecated warning many people get in their install process.

Other changes:

* Added `endOfLine` option to prettier rc to avoid [this](https://stackoverflow.com/questions/53516594/why-do-i-keep-getting-delete-cr-prettier-prettier):
![screenshot of error described in stackoverflow question, from testing the package](https://user-images.githubusercontent.com/7024578/117815726-aaab7c80-b25d-11eb-8f50-15a8df176e18.png)


## Test Plan

`yarn build e2e:android` doesn't work on my Windows machine, I'll test on my Mac when I next can. Behaviour should be the same minus some small edge cases.