### PR TITLE
chore: replace jcenter() with mavenCentral()

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -39,7 +39,7 @@ buildscript {
 
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
         if (project == rootProject) {
@@ -99,7 +99,7 @@ repositories {
         url "${resolveModulePath("react-native")}/android"
     }
     google()
-    jcenter()
+    mavenCentral()
 }
 
 dependencies {

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -38,7 +38,7 @@ buildscript {
 
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
         // Needs to match `react-native-test-app/android/app/build.gradle`


### PR DESCRIPTION
## Summary
JCenter is deprecated and end of service. Replace JCenter with Maven Central.
The open issue: https://github.com/react-native-async-storage/async-storage/issues/610

## Test Plan
`yarn build:e2e:android`