### PR TITLE
remove buildToolsVersion

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -74,7 +74,6 @@ if (useNextStorage) {
 
 android {
     compileSdkVersion safeExtGet('compileSdkVersion', 28)
-    buildToolsVersion safeExtGet('buildToolsVersion', '28.0.3')
     defaultConfig {
         minSdkVersion safeExtGet('minSdkVersion', 19)
         targetSdkVersion safeExtGet('targetSdkVersion', 28)


### PR DESCRIPTION
## Summary

Setting buildToolsVersion is no longer recommended, it'll default to Android Gradle Plugin defaults. It makes DX worse by requiring multiple versions of build tools by various dependencies require various versions.

## Test Plan

No visible changes, everything will work as before.