### PR TITLE
fix(web): replace deprecated deep-assign with merge-options

### DIFF
--- a/jest/async-storage-mock.js
+++ b/jest/async-storage-mock.js
@@ -2,6 +2,13 @@
  * @format
  */
 
+import mergeOptions from 'merge-options';
+
+const merge = mergeOptions.bind({
+  concatArrays: true,
+  ignoreUndefined: true,
+});
+
 const asMock = {
   __INTERNAL_MOCK_STORAGE__: {},
 
@@ -95,31 +102,12 @@ async function _multiMerge(keyValuePairs, callback) {
     const oldValue = JSON.parse(asMock.__INTERNAL_MOCK_STORAGE__[key]);
 
     asMock.__INTERNAL_MOCK_STORAGE__[key] = JSON.stringify(
-      _deepMergeInto(oldValue, value),
+      merge(oldValue, value),
     );
   });
 
   callback && callback(null);
   return null;
 }
-
-const _isObject = (obj) => typeof obj === 'object' && !Array.isArray(obj);
-const _deepMergeInto = (oldObject, newObject) => {
-  const newKeys = Object.keys(newObject);
-  const mergedObject = oldObject;
-
-  newKeys.forEach((key) => {
-    const oldValue = mergedObject[key];
-    const newValue = newObject[key];
-
-    if (_isObject(oldValue) && _isObject(newValue)) {
-      mergedObject[key] = _deepMergeInto(oldValue, newValue);
-    } else {
-      mergedObject[key] = newValue;
-    }
-  });
-
-  return mergedObject;
-};
 
 module.exports = asMock;

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "test:e2e:macos": "scripts/macos_e2e.sh 'test'"
   },
   "dependencies": {
-    "deep-assign": "^3.0.0"
+    "merge-options": "^3.0.4"
   },
   "peerDependencies": {
     "react-native": "^0.60.6 || ^0.61.5 || ^0.62.2 || ^0.63.2 || ^0.64.0 || 1000.0.0"

--- a/src/AsyncStorage.js
+++ b/src/AsyncStorage.js
@@ -8,13 +8,18 @@
  * @flow
  */
 
-import merge from 'deep-assign';
+import mergeOptions from 'merge-options';
+
+const merge = mergeOptions.bind({
+  concatArrays: true,
+  ignoreUndefined: true,
+});
 
 const mergeLocalStorageItem = (key, value) => {
   const oldValue = window.localStorage.getItem(key);
   const oldObject = JSON.parse(oldValue);
   const newObject = JSON.parse(value);
-  const nextValue = JSON.stringify(merge({}, oldObject, newObject));
+  const nextValue = JSON.stringify(merge(oldObject, newObject));
   window.localStorage.setItem(key, nextValue);
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -9322,6 +9322,13 @@ meow@^8.0.0:
     type-fest "^0.18.0"
     yargs-parser "^20.2.3"
 
+merge-options@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/merge-options/-/merge-options-3.0.4.tgz#84709c2aa2a4b24c1981f66c179fe5565cc6dbb7"
+  integrity sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==
+  dependencies:
+    is-plain-obj "^2.1.0"
+
 merge-stream@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/merge-stream/-/merge-stream-1.0.1.tgz#4041202d508a342ba00174008df0c251b8c135e1"


### PR DESCRIPTION
## Summary

Replaces deprecated [deep-assign](https://www.npmjs.com/package/deep-assign) with [merge-options](https://github.com/schnittstabil/merge-options).

Resolves #374.
Supersedes #601.

## Test Plan

CI should pass.