### PR TITLE
fix(mock): cannot use import statement outside a module

### DIFF
--- a/jest/async-storage-mock.js
+++ b/jest/async-storage-mock.js
@@ -2,9 +2,7 @@
  * @format
  */
 
-import mergeOptions from 'merge-options';
-
-const merge = mergeOptions.bind({
+const merge = require('merge-options').bind({
   concatArrays: true,
   ignoreUndefined: true,
 });


### PR DESCRIPTION
## Summary

Users are hitting `SyntaxError: Cannot use import statement outside a module` using `/jest/async-storage-mock.js` in latest version.

Resolves #660

## Test Plan

Tests should pass.