### PR TITLE
fix(android): prefer downloading dependencies from Maven Central

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -39,6 +39,7 @@ buildscript {
 
     repositories {
         google()
+        mavenCentral()
         jcenter()
     }
     dependencies {
@@ -98,6 +99,7 @@ repositories {
         url "${resolveModulePath("react-native")}/android"
     }
     google()
+    mavenCentral()
     jcenter()
 }
 

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -39,6 +39,7 @@ buildscript {
 
     repositories {
         google()
+        mavenCentral()
         jcenter()
     }
     dependencies {


### PR DESCRIPTION
## Summary

Recent react-native dependencies are published to Maven Central only.

## Test Plan

CI should pass.