### PR TITLE
Upgrade Kotlin to 1.5 and Room to 2.3.0

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -35,7 +35,7 @@ buildscript {
             ? rootProject.ext['kotlinVersion']
             : rootProject.hasProperty('AsyncStorage_kotlinVersion')
             ? rootProject.properties['AsyncStorage_kotlinVersion']
-            : '1.4.21'
+            : '1.5.31'
 
     repositories {
         google()
@@ -106,7 +106,7 @@ repositories {
 dependencies {
 
     if (useNextStorage) {
-        def room_version = "2.2.6"
+        def room_version = "2.3.0"
         def coroutines_version = "1.4.2"
         def junit_version = "4.12"
         def robolectric_version = "4.5.1"


### PR DESCRIPTION
## Summary

My app uses Kotlin 1.5 and I cannot downgrade to 1.4, so I upgraded locally to 1.5. It appeared I also needed to upgrade Room to the last stable version.
I'm not sure if this is a breaking change, or maybe it would be better to let users choose their room version.
