### PR TITLE
chore: remove usage of `jcenter()`

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -40,7 +40,6 @@ buildscript {
     repositories {
         google()
         mavenCentral()
-        jcenter()
     }
     dependencies {
         if (project == rootProject) {
@@ -100,7 +99,6 @@ repositories {
     }
     google()
     mavenCentral()
-    jcenter()
 }
 
 dependencies {


### PR DESCRIPTION
## Summary

I got a warning message about shuting down jcenter.

> WARNING:: Please remove usages of `jcenter()` Maven repository from your build scripts and migrate your build to other Maven repositories.
This repository is deprecated and it will be shut down in the future.
See http://developer.android.com/r/tools/jcenter-end-of-service for more information.

Using this information we can drop this repo from gradle file.
