### PR TITLE
Bump Stale version to v4

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -9,7 +9,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-    - uses: actions/stale@v3
+    - uses: actions/stale@v4
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-issue-message: 'This issue has been marked as stale due to inactivity. Please respond or otherwise resolve the issue within 7 days or it will be closed.'


### PR DESCRIPTION
## Summary

Just a small PR to bump the version of `actions/stale` as the v4 is out
