### PR TITLE
chore(jcenter): remove usage of jcenter()

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -99,7 +99,6 @@ repositories {
     }
     google()
     mavenCentral()
-    mavenLocal()
 }
 
 dependencies {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -40,7 +40,6 @@ buildscript {
     repositories {
         google()
         mavenCentral()
-        jcenter()
     }
     dependencies {
         if (project == rootProject) {
@@ -100,7 +99,7 @@ repositories {
     }
     google()
     mavenCentral()
-    jcenter()
+    mavenLocal()
 }
 
 dependencies {

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -53,6 +53,7 @@ allprojects {
         maven {
             url("$rootDir/../../node_modules/detox/Detox-android")
         }
+        jcenter()
     }
     afterEvaluate { project ->
         def androidExtension = project.extensions.findByName('android')


### PR DESCRIPTION
@tido64 said:
> Unfortunately, we cannot remove JCenter without breaking people on older versions of React Native:

I disagree with it and I will proof soon:)

Refs: #610, #680, #681, #666, #611

## Summary

<!--
  Thank you for submitting a PR!

  Help us understand more of your work - you can explain what you did, post a
  link to an issue, screenshots etc. Anything helps!
-->

I was read some treads in this repo and saw the [wrong conclusion](https://github.com/react-native-async-storage/async-storage/issues/610#issuecomment-917394117):c

I guess @tido64 gets error because in this repo use [react-native-test-app](https://github.com/microsoft/react-native-test-app) for example 

react-native-test-app dont have jcenter() into [build.gradle](https://github.com/microsoft/react-native-test-app/blob/trunk/android/build.gradle)

But old react-native project have  jcenter() inside [build.gradle](https://github.com/Bibazavr/AsyncStorageOldRN/blob/main/android/build.gradle) and all works fine. [Proof](https://github.com/Bibazavr/AsyncStorageOldRN)

with new RN all work's fine too:3  
## Test Plan

<!--
    Help us test your work (**REQUIRED**).

    If you changed the code, please provide us with instructions of how we can
    try it out ourselves, so we can confirm it's working. You can also post
    screenshots/gifts.
-->

go to [Proof](https://github.com/Bibazavr/AsyncStorageOldRN) and check up - all works fine:o
