### PR TITLE
fix: Gradle build failing for version 1.15.10

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -37,7 +37,9 @@ buildscript {
     // kotlin version is dictated by rootProject extension or property in gradle.properties
     ext.asyncStorageKtVersion = rootProject.ext.has('kotlinVersion')
             ? rootProject.ext['kotlinVersion']
-            : getVersionOrDefault('AsyncStorage_kotlinVersion', '1.5.31')
+            : rootProject.hasProperty('AsyncStorage_kotlinVersion')
+            ? rootProject.properties['AsyncStorage_kotlinVersion']
+            : '1.5.31'
 
     repositories {
         google()


### PR DESCRIPTION
## Summary

Could reproduce this in a clean project, but not on our example app. Because method used inside `buildscript` is not reachable, I instead read properties directly.


