### PR TITLE
Make web version work without unknown env vars set

### DIFF
--- a/packages/core/src/defaults.ts
+++ b/packages/core/src/defaults.ts
@@ -10,7 +10,7 @@ import {FactoryOptions, LoggerAction} from '../types';
 
 const isDevelopment =
   // @ts-ignore
-  (process && process.env && process.env.NODE_ENV === 'development') || __DEV__;
+  (typeof process !== 'undefined' && process.env && process.env.NODE_ENV === 'development') || (typeof __DEV__ !== 'undefined' && __DEV__);
 
 export const factoryOptions: FactoryOptions = {
   logger: isDevelopment,


### PR DESCRIPTION
Web doesn't have process.env.NODE_ENV nor __DEV __ vars set.
Checking for these vars will raise an `Uncaught ReferenceError`.

In my case, i use webpack to replace process.env.NODE_ENV with a value at build time, but the `process && ...` check would still raise an error (and replacing process object [isn't good, see warning on webpack docs](https://webpack.js.org/plugins/define-plugin/))