### PR TITLE
chore: add type definition for jest mock

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ default config for android apk builds: &android_defaults
   resource_class: 'medium'
   working_directory: ~/async_storage
   environment:
-    - _JAVA_OPTIONS: '-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -Xmx2048m'
+    - _JAVA_OPTIONS: '-XX:+UnlockExperimentalVMOptions -Xmx2048m'
     - GRADLE_OPTS: '-Dorg.gradle.daemon=false -Dorg.gradle.jvmargs="-XX:+HeapDumpOnOutOfMemoryError -Xmx2048m"'
     - BUILD_THREADS: 2
 

--- a/.releaserc
+++ b/.releaserc
@@ -1,5 +1,19 @@
 {
   "branches": [
     "master"
+  ],
+  "plugins": [
+    "@semantic-release/commit-analyzer",
+    "@semantic-release/release-notes-generator",
+    "@semantic-release/changelog",
+    "@semantic-release/npm",
+    "@semantic-release/github",
+    [
+      "@semantic-release/git",
+      {
+        "assets": ["CHANGELOG.md", "package.json"],
+        "message": "chore(release): ${nextRelease.version} [skip ci]"
+      }
+    ]
   ]
 }

--- a/package.json
+++ b/package.json
@@ -74,6 +74,8 @@
     "@react-native-community/cli-platform-android": "^4.10.0",
     "@react-native-community/cli-platform-ios": "^4.10.0",
     "@react-native-community/eslint-config": "^3.0.0",
+    "@semantic-release/changelog": "^5.0.1",
+    "@semantic-release/git": "9.0.0",
     "detox": "17.10.6",
     "eslint": "^7.0.0",
     "expo": "^38.0.10",
@@ -92,7 +94,7 @@
     "react-native-web": "~0.12.0",
     "react-native-windows": "^0.63.41",
     "react-test-renderer": "16.13.1",
-    "semantic-release": "^17.2.1"
+    "semantic-release": "^17.4.6"
   },
   "jest": {
     "preset": "react-native",
@@ -133,7 +135,12 @@
     "source": "src",
     "output": "lib",
     "targets": [
-      ["commonjs", { "copyFlow": true }],
+      [
+        "commonjs",
+        {
+          "copyFlow": true
+        }
+      ],
       "module"
     ]
   }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -86,3 +86,34 @@ declare module '@react-native-async-storage/async-storage' {
 
   export default AsyncStorage;
 }
+
+declare module '@react-native-async-storage/async-storage/jest/async-storage-mock' {
+   export interface AsyncStorageStatic {
+    getItem(key: string, callback?: (error?: Error, result?: string) => void): Promise<string | null>;
+    setItem(key: string, value: string, callback?: (error?: Error) => void): Promise<void>;
+    removeItem(key: string, callback?: (error?: Error) => void): Promise<void>;
+    mergeItem(key: string, value: string, callback?: (error?: Error) => void): Promise<void>;
+
+    clear(callback?: (error?: Error) => void): Promise<void>;
+    getAllKeys(callback?: (error?: Error, keys?: string[]) => void): Promise<string[]>;
+
+    multiGet(
+      keys: string[],
+      callback?: (errors?: Error[], result?: [string, string | null][]) => void
+    ): Promise<[string, string | null][]>;
+    multiSet(keyValuePairs: string[][], callback?: (errors?: Error[]) => void): Promise<void>;
+    multiRemove(keys: string[], callback?: (errors?: Error[]) => void): Promise<void>;
+    multiMerge(keyValuePairs: string[][], callback?: (errors?: Error[]) => void): Promise<void>;
+  }
+
+  export function useAsyncStorage(key: string): {
+    getItem(callback?: (error?: Error, result?: string) => void): Promise<string | null>;
+    setItem(value: string, callback?: (error?: Error) => void): Promise<void>;
+    mergeItem(value: string, callback?: (error?: Error) => void): Promise<void>;
+    removeItem(callback?: (error?: Error) => void): Promise<void>;
+  }
+
+  const AsyncStorage: AsyncStorageStatic;
+
+  export default AsyncStorage;
+}

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,5 +1,71 @@
 // CREDITS: This types are based on the original work made by all the people who contributed to @types/react-native
 
+interface AsyncStorage {
+  /**
+   * Fetches key and passes the result to callback, along with an Error if there is any.
+   */
+  getItem(key: string, callback?: (error?: Error, result?: string) => void): Promise<string | null>;
+
+  /**
+   * Sets value for key and calls callback on completion, along with an Error if there is any
+   */
+  setItem(key: string, value: string, callback?: (error?: Error) => void): Promise<void>;
+
+  removeItem(key: string, callback?: (error?: Error) => void): Promise<void>;
+
+  /**
+   * Merges existing value with input value, assuming they are stringified json. Returns a Promise object.
+   * Not supported by all native implementation
+   */
+  mergeItem(key: string, value: string, callback?: (error?: Error) => void): Promise<void>;
+
+  /**
+   * Erases all AsyncStorage for all clients, libraries, etc. You probably don't want to call this.
+   * Use removeItem or multiRemove to clear only your own keys instead.
+   */
+  clear(callback?: (error?: Error) => void): Promise<void>;
+
+  /**
+   * Gets all keys known to the app, for all callers, libraries, etc
+   */
+  getAllKeys(callback?: (error?: Error, keys?: string[]) => void): Promise<string[]>;
+
+  /**
+   * multiGet invokes callback with an array of key-value pair arrays that matches the input format of multiSet
+   */
+  multiGet(
+    keys: string[],
+    callback?: (errors?: Error[], result?: [string, string | null][]) => void
+  ): Promise<[string, string | null][]>;
+
+  /**
+   * multiSet and multiMerge take arrays of key-value array pairs that match the output of multiGet,
+   *
+   * multiSet([['k1', 'val1'], ['k2', 'val2']], cb);
+   */
+  multiSet(keyValuePairs: string[][], callback?: (errors?: Error[]) => void): Promise<void>;
+
+  /**
+   * Delete all the keys in the keys array.
+   */
+  multiRemove(keys: string[], callback?: (errors?: Error[]) => void): Promise<void>;
+
+  /**
+   * Merges existing values with input values, assuming they are stringified json.
+   * Returns a Promise object.
+   *
+   * Not supported by all native implementations.
+   */
+  multiMerge(keyValuePairs: string[][], callback?: (errors?: Error[]) => void): Promise<void>;
+}
+
+type AsyncStorageHook = {
+  getItem(callback?: (error?: Error, result?: string) => void): Promise<string | null>;
+  setItem(value: string, callback?: (error?: Error) => void): Promise<void>;
+  mergeItem(value: string, callback?: (error?: Error) => void): Promise<void>;
+  removeItem(callback?: (error?: Error) => void): Promise<void>;
+}
+
 declare module '@react-native-async-storage/async-storage' {
   /**
    * AsyncStorage is a simple, unencrypted, asynchronous, persistent, key-value storage
@@ -16,104 +82,13 @@ declare module '@react-native-async-storage/async-storage' {
    *
    * @see https://react-native-async-storage.github.io/async-storage/docs/api
    */
-  export interface AsyncStorageStatic {
-    /**
-     * Fetches key and passes the result to callback, along with an Error if there is any.
-     */
-    getItem(key: string, callback?: (error?: Error, result?: string) => void): Promise<string | null>;
-
-    /**
-     * Sets value for key and calls callback on completion, along with an Error if there is any
-     */
-    setItem(key: string, value: string, callback?: (error?: Error) => void): Promise<void>;
-
-    removeItem(key: string, callback?: (error?: Error) => void): Promise<void>;
-
-    /**
-     * Merges existing value with input value, assuming they are stringified json. Returns a Promise object.
-     * Not supported by all native implementation
-     */
-    mergeItem(key: string, value: string, callback?: (error?: Error) => void): Promise<void>;
-
-    /**
-     * Erases all AsyncStorage for all clients, libraries, etc. You probably don't want to call this.
-     * Use removeItem or multiRemove to clear only your own keys instead.
-     */
-    clear(callback?: (error?: Error) => void): Promise<void>;
-
-    /**
-     * Gets all keys known to the app, for all callers, libraries, etc
-     */
-    getAllKeys(callback?: (error?: Error, keys?: string[]) => void): Promise<string[]>;
-
-    /**
-     * multiGet invokes callback with an array of key-value pair arrays that matches the input format of multiSet
-     */
-    multiGet(
-      keys: string[],
-      callback?: (errors?: Error[], result?: [string, string | null][]) => void
-    ): Promise<[string, string | null][]>;
-
-    /**
-     * multiSet and multiMerge take arrays of key-value array pairs that match the output of multiGet,
-     *
-     * multiSet([['k1', 'val1'], ['k2', 'val2']], cb);
-     */
-    multiSet(keyValuePairs: string[][], callback?: (errors?: Error[]) => void): Promise<void>;
-
-    /**
-     * Delete all the keys in the keys array.
-     */
-    multiRemove(keys: string[], callback?: (errors?: Error[]) => void): Promise<void>;
-
-    /**
-     * Merges existing values with input values, assuming they are stringified json.
-     * Returns a Promise object.
-     *
-     * Not supported by all native implementations.
-     */
-    multiMerge(keyValuePairs: string[][], callback?: (errors?: Error[]) => void): Promise<void>;
-  }
-
-  export function useAsyncStorage(key: string): {
-    getItem(callback?: (error?: Error, result?: string) => void): Promise<string | null>;
-    setItem(value: string, callback?: (error?: Error) => void): Promise<void>;
-    mergeItem(value: string, callback?: (error?: Error) => void): Promise<void>;
-    removeItem(callback?: (error?: Error) => void): Promise<void>;
-  }
-
-  const AsyncStorage: AsyncStorageStatic;
-
-  export default AsyncStorage;
+  export function useAsyncStorage(key: string): AsyncStorageHook
+  const AsyncStorageLib: AsyncStorage;
+  export default AsyncStorageLib;
 }
 
 declare module '@react-native-async-storage/async-storage/jest/async-storage-mock' {
-   export interface AsyncStorageStatic {
-    getItem(key: string, callback?: (error?: Error, result?: string) => void): Promise<string | null>;
-    setItem(key: string, value: string, callback?: (error?: Error) => void): Promise<void>;
-    removeItem(key: string, callback?: (error?: Error) => void): Promise<void>;
-    mergeItem(key: string, value: string, callback?: (error?: Error) => void): Promise<void>;
-
-    clear(callback?: (error?: Error) => void): Promise<void>;
-    getAllKeys(callback?: (error?: Error, keys?: string[]) => void): Promise<string[]>;
-
-    multiGet(
-      keys: string[],
-      callback?: (errors?: Error[], result?: [string, string | null][]) => void
-    ): Promise<[string, string | null][]>;
-    multiSet(keyValuePairs: string[][], callback?: (errors?: Error[]) => void): Promise<void>;
-    multiRemove(keys: string[], callback?: (errors?: Error[]) => void): Promise<void>;
-    multiMerge(keyValuePairs: string[][], callback?: (errors?: Error[]) => void): Promise<void>;
-  }
-
-  export function useAsyncStorage(key: string): {
-    getItem(callback?: (error?: Error, result?: string) => void): Promise<string | null>;
-    setItem(value: string, callback?: (error?: Error) => void): Promise<void>;
-    mergeItem(value: string, callback?: (error?: Error) => void): Promise<void>;
-    removeItem(callback?: (error?: Error) => void): Promise<void>;
-  }
-
-  const AsyncStorage: AsyncStorageStatic;
-
-  export default AsyncStorage;
+  export function useAsyncStorage(key: string): AsyncStorageHook
+  const AsyncStorageLib: AsyncStorage;
+  export default AsyncStorageLib;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2278,6 +2278,16 @@
   dependencies:
     applicationinsights "^1.8.8"
 
+"@semantic-release/changelog@^5.0.1":
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/@semantic-release/changelog/-/changelog-5.0.1.tgz#50a84b63e5d391b7debfe021421589fa2bcdafe4"
+  integrity sha512-unvqHo5jk4dvAf2nZ3aw4imrlwQ2I50eVVvq9D47Qc3R+keNqepx1vDYwkjF8guFXnOYaYcR28yrZWno1hFbiw==
+  dependencies:
+    "@semantic-release/error" "^2.1.0"
+    aggregate-error "^3.0.0"
+    fs-extra "^9.0.0"
+    lodash "^4.17.4"
+
 "@semantic-release/commit-analyzer@^8.0.0":
   version "8.0.1"
   resolved "https://registry.yarnpkg.com/@semantic-release/commit-analyzer/-/commit-analyzer-8.0.1.tgz#5d2a37cd5a3312da0e3ac05b1ca348bf60b90bca"
@@ -2291,10 +2301,24 @@
     lodash "^4.17.4"
     micromatch "^4.0.2"
 
-"@semantic-release/error@^2.2.0":
+"@semantic-release/error@^2.1.0", "@semantic-release/error@^2.2.0":
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/@semantic-release/error/-/error-2.2.0.tgz#ee9d5a09c9969eade1ec864776aeda5c5cddbbf0"
   integrity sha512-9Tj/qn+y2j+sjCI3Jd+qseGtHjOAeg7dU2/lVcqIQ9TV3QDaDXDYXcoOHU+7o2Hwh8L8ymL4gfuO7KxDs3q2zg==
+
+"@semantic-release/git@9.0.0":
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/@semantic-release/git/-/git-9.0.0.tgz#304c4883c87d095b1faaae93300f1f1e0466e9a5"
+  integrity sha512-AZ4Zha5NAPAciIJH3ipzw/WU9qLAn8ENaoVAhD6srRPxTpTzuV3NhNh14rcAo8Paj9dO+5u4rTKcpetOBluYVw==
+  dependencies:
+    "@semantic-release/error" "^2.1.0"
+    aggregate-error "^3.0.0"
+    debug "^4.0.0"
+    dir-glob "^3.0.0"
+    execa "^4.0.0"
+    lodash "^4.17.4"
+    micromatch "^4.0.0"
+    p-reduce "^2.0.0"
 
 "@semantic-release/github@^7.0.0":
   version "7.2.3"
@@ -9634,7 +9658,7 @@ micromatch@^3.1.10, micromatch@^3.1.4:
     snapdragon "^0.8.1"
     to-regex "^3.0.2"
 
-micromatch@^4.0.2, micromatch@^4.0.4:
+micromatch@^4.0.0, micromatch@^4.0.2, micromatch@^4.0.4:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.4.tgz#896d519dfe9db25fce94ceb7a500919bf881ebf9"
   integrity sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==
@@ -12514,10 +12538,10 @@ schema-utils@^3.0.0:
     ajv "^6.12.5"
     ajv-keywords "^3.5.2"
 
-semantic-release@^17.2.1:
-  version "17.4.4"
-  resolved "https://registry.yarnpkg.com/semantic-release/-/semantic-release-17.4.4.tgz#650dd50ecb520a5a2bc6811305bc9d4d5c3128b1"
-  integrity sha512-fQIA0lw2Sy/9+TcoM/BxyzKCSwdUd8EPRwGoOuBLgxKigPCY6kaKs8TOsgUVy6QrlTYwni2yzbMb5Q2107P9eA==
+semantic-release@^17.4.6:
+  version "17.4.7"
+  resolved "https://registry.yarnpkg.com/semantic-release/-/semantic-release-17.4.7.tgz#88e1dce7294cc43acc54c4e0a83f582264567206"
+  integrity sha512-3Ghu8mKCJgCG3QzE5xphkYWM19lGE3XjFdOXQIKBM2PBpBvgFQ/lXv31oX0+fuN/UjNFO/dqhNs8ATLBhg6zBg==
   dependencies:
     "@semantic-release/commit-analyzer" "^8.0.0"
     "@semantic-release/error" "^2.2.0"


### PR DESCRIPTION
## Summary

<!--
  Thank you for submitting a PR!

  Help us understand more of your work - you can explain what you did, post a
  link to an issue, screenshots etc. Anything helps!
-->
According to [with-jest-setup-file jest integration](https://react-native-async-storage.github.io/async-storage/docs/advanced/jest#with-jest-setup-file), I tried to test `app.test.tsx` file using [ts-jest](https://kulshekhar.github.io/ts-jest/) and followed 
```ts
import mockAsyncStorage from '@react-native-async-storage/async-storage/jest/async-storage-mock';
```
throws ts(7016) error.
<img width="717" alt="스크린샷 2021-11-09 오후 2 58 29" src="https://user-images.githubusercontent.com/16593102/140870554-66a54992-48de-445e-8669-a3759709317d.png">

## Test Plan

<!--
    Help us test your work (**REQUIRED**).

    If you changed the code, please provide us with instructions of how we can
    try it out ourselves, so we can confirm it's working. You can also post
    screenshots/gifts.
-->
If you use this change with ts-jest, the error disappears.