### PR TITLE
Fix wrong method referenced in validated input warning

### DIFF
--- a/src/AsyncStorage.native.js
+++ b/src/AsyncStorage.native.js
@@ -59,7 +59,7 @@ function checkValidInput(usedKey: string, value: any) {
   if (isValuePassed && typeof value !== 'string') {
     if (value == null) {
       throw new Error(
-        `[AsyncStorage] Passing null/undefined as value is not supported. If you want to remove value, Use .remove method instead.\nPassed value: ${value}\nPassed key: ${usedKey}\n`,
+        `[AsyncStorage] Passing null/undefined as value is not supported. If you want to remove value, Use .removeItem method instead.\nPassed value: ${value}\nPassed key: ${usedKey}\n`,
       );
     } else {
       console.warn(


### PR DESCRIPTION
## Summary

Whenever you pass `null` as a value for `.setItem()`, you will see an error. It will tell you to use `.remove` instead, however that method doesn't exist, it should be `.removeItem`. I think so, at least 🤷 

## Test Plan

You can test this by throwing the error, see the example below.

```js
import AsyncStorage from '@react-native-async-storage/async-storage';

AsyncStorage.setItem('bla', null);
```