### PR TITLE
fix(windows): Fix crash when running windows module

### DIFF
--- a/example/windows/ReactTestApp.sln
+++ b/example/windows/ReactTestApp.sln
@@ -35,22 +35,21 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Mso", "..\..\node_modules\r
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Include", "..\..\node_modules\react-native-windows\include\Include.vcxitems", "{EF074BA1-2D54-4D49-A28E-5E040B47CD2E}"
 EndProject
-
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ReactNativeAsyncStorage", "..\..\windows\ReactNativeAsyncStorage\ReactNativeAsyncStorage.vcxproj", "{4855D892-E16C-404D-8286-0089E0F7F9C4}"
 EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
-		..\node_modules\react-native-windows\JSI\Shared\JSI.Shared.vcxitems*{0cc28589-39e4-4288-b162-97b959f8b843}*SharedItemsImports = 9
-		..\node_modules\react-native-windows\Shared\Shared.vcxitems*{2049dbe9-8d13-42c9-ae4b-413ae38fffd0}*SharedItemsImports = 9
-		..\node_modules\react-native-windows\Mso\Mso.vcxitems*{84e05bfa-cbaf-4f0d-bfb6-4ce85742a57e}*SharedItemsImports = 9
-		..\node_modules\react-native-windows\JSI\Shared\JSI.Shared.vcxitems*{a62d504a-16b8-41d2-9f19-e2e86019e5e4}*SharedItemsImports = 4
-		..\node_modules\react-native-windows\Chakra\Chakra.vcxitems*{c38970c0-5fbf-4d69-90d8-cbac225ae895}*SharedItemsImports = 9
-		..\node_modules\react-native-windows\Microsoft.ReactNative.Cxx\Microsoft.ReactNative.Cxx.vcxitems*{da8b35b3-da00-4b02-bde6-6a397b3fd46b}*SharedItemsImports = 9
-		..\node_modules\react-native-windows\include\Include.vcxitems*{ef074ba1-2d54-4d49-a28e-5e040b47cd2e}*SharedItemsImports = 9
-		..\node_modules\react-native-windows\Chakra\Chakra.vcxitems*{f7d32bd0-2749-483e-9a0d-1635ef7e3136}*SharedItemsImports = 4
-		..\node_modules\react-native-windows\Microsoft.ReactNative.Cxx\Microsoft.ReactNative.Cxx.vcxitems*{f7d32bd0-2749-483e-9a0d-1635ef7e3136}*SharedItemsImports = 4
-		..\node_modules\react-native-windows\Mso\Mso.vcxitems*{f7d32bd0-2749-483e-9a0d-1635ef7e3136}*SharedItemsImports = 4
-		..\node_modules\react-native-windows\Shared\Shared.vcxitems*{f7d32bd0-2749-483e-9a0d-1635ef7e3136}*SharedItemsImports = 4
+		..\..\node_modules\react-native-windows\JSI\Shared\JSI.Shared.vcxitems*{0cc28589-39e4-4288-b162-97b959f8b843}*SharedItemsImports = 9
+		..\..\node_modules\react-native-windows\Shared\Shared.vcxitems*{2049dbe9-8d13-42c9-ae4b-413ae38fffd0}*SharedItemsImports = 9
+		..\..\node_modules\react-native-windows\Mso\Mso.vcxitems*{84e05bfa-cbaf-4f0d-bfb6-4ce85742a57e}*SharedItemsImports = 9
+		..\..\node_modules\react-native-windows\JSI\Shared\JSI.Shared.vcxitems*{a62d504a-16b8-41d2-9f19-e2e86019e5e4}*SharedItemsImports = 4
+		..\..\node_modules\react-native-windows\Chakra\Chakra.vcxitems*{c38970c0-5fbf-4d69-90d8-cbac225ae895}*SharedItemsImports = 9
+		..\..\node_modules\react-native-windows\Microsoft.ReactNative.Cxx\Microsoft.ReactNative.Cxx.vcxitems*{da8b35b3-da00-4b02-bde6-6a397b3fd46b}*SharedItemsImports = 9
+		..\..\node_modules\react-native-windows\include\Include.vcxitems*{ef074ba1-2d54-4d49-a28e-5e040b47cd2e}*SharedItemsImports = 9
+		..\..\node_modules\react-native-windows\Chakra\Chakra.vcxitems*{f7d32bd0-2749-483e-9a0d-1635ef7e3136}*SharedItemsImports = 4
+		..\..\node_modules\react-native-windows\Microsoft.ReactNative.Cxx\Microsoft.ReactNative.Cxx.vcxitems*{f7d32bd0-2749-483e-9a0d-1635ef7e3136}*SharedItemsImports = 4
+		..\..\node_modules\react-native-windows\Mso\Mso.vcxitems*{f7d32bd0-2749-483e-9a0d-1635ef7e3136}*SharedItemsImports = 4
+		..\..\node_modules\react-native-windows\Shared\Shared.vcxitems*{f7d32bd0-2749-483e-9a0d-1635ef7e3136}*SharedItemsImports = 4
 	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|ARM = Debug|ARM

--- a/windows/ReactNativeAsyncStorage/ReactNativeAsyncStorage.vcxproj
+++ b/windows/ReactNativeAsyncStorage/ReactNativeAsyncStorage.vcxproj
@@ -161,7 +161,7 @@
   <ImportGroup Label="ExtensionTargets">
     <Import Project="$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.200316.3\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.200316.3\build\native\Microsoft.Windows.CppWinRT.targets')" />
   </ImportGroup>
-  <Target Name="Deploy"/>
+  <Target Name="Deploy" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>

--- a/windows/code/DBStorage.cpp
+++ b/windows/code/DBStorage.cpp
@@ -208,8 +208,8 @@ namespace
 
     // Merge source into destination.
     // It only merges objects - all other types are just clobbered (including arrays).
-    void MergeJsonObjects(winrt::Windows::Data::Json::JsonObject const &destination,
-                          winrt::Windows::Data::Json::JsonObject const &source) noexcept
+    void MergeJsonObjects(winrt::JsonObject const &destination,
+                          winrt::JsonObject const &source) noexcept
     {
         for (auto keyValue : source) {
             auto key = keyValue.Key();

--- a/windows/code/DBStorage.cpp
+++ b/windows/code/DBStorage.cpp
@@ -574,6 +574,9 @@ void ReadValue(const winrt::IJSValueReader &reader,
             }
             ++index;
         }
+    } else {
+        // To keep reader in a good state.
+        winrt::SkipValue<winrt::JSValue>(reader);
     }
 }
 

--- a/windows/code/DBStorage.cpp
+++ b/windows/code/DBStorage.cpp
@@ -216,9 +216,8 @@ namespace
             auto sourceValue = keyValue.Value();
             if (destination.HasKey(key)) {
                 auto destinationValue = destination.GetNamedValue(key);
-                if (destinationValue.ValueType() ==
-                        winrt::Windows::Data::Json::JsonValueType::Object &&
-                    sourceValue.ValueType() == winrt::Windows::Data::Json::JsonValueType::Object) {
+                if (destinationValue.ValueType() == winrt::JsonValueType::Object &&
+                    sourceValue.ValueType() == winrt::JsonValueType::Object) {
                     MergeJsonObjects(destinationValue.GetObject(), sourceValue.GetObject());
                     continue;
                 }

--- a/windows/code/DBStorage.h
+++ b/windows/code/DBStorage.h
@@ -91,7 +91,7 @@ struct DBStorage {
 
     private:
         ErrorHandler m_errorHandler;
-        std::atomic_flag m_isCompleted{false};
+        std::atomic_flag m_isCompleted = ATOMIC_FLAG_INIT;
         TOnResolve m_onResolve;
         TOnReject m_onReject;
     };

--- a/windows/code/DBStorage.h
+++ b/windows/code/DBStorage.h
@@ -1,71 +1,160 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 #pragma once
+
+#include <optional>
 
 #include <winsqlite/winsqlite3.h>
 
 #include "NativeModules.h"
 
-class DBStorage
-{
-public:
-    typedef std::function<void(std::vector<winrt::Microsoft::ReactNative::JSValue> const &)>
-        Callback;
+struct DBStorage {
+    // To pass KeyValue pairs in the native module API.
+    // It has custom ReadValue and WriteValue to read/write to/from JSON.
+    struct KeyValue {
+        std::string Key;
+        std::string Value;
+    };
 
-    class DBTask
-    {
-    public:
-        enum class Type { multiGet, multiSet, multiRemove, clear, getAllKeys };
+    // An Error object for the native module API.
+    // It has a custom WriteValue to write to JSON.
+    struct Error {
+        std::string Message;
+    };
 
-        DBTask(Type type,
-               std::vector<winrt::Microsoft::ReactNative::JSValue> &&args,
-               Callback &&callback)
-            : m_type{type}, m_args{std::move(args)}, m_callback{std::move(callback)}
+    // An error list shared between Promise and DBTask.
+    struct ErrorHandler {
+        std::nullopt_t AddError(std::string &&message) noexcept;
+        const std::vector<Error> &GetErrors() const noexcept;
+
+    private:
+        std::vector<Error> m_errors;
+    };
+
+    // Ensure that only one result onResolve or onReject callback is called once.
+    template <typename TOnResolve, typename TOnReject>
+    struct Promise {
+
+        Promise(TOnResolve &&onResolve, TOnReject &&onReject) noexcept
+            : m_onResolve(std::move(onResolve)), m_onReject(std::move(onReject))
         {
         }
 
-        DBTask(const DBTask &) = delete;
-        DBTask(DBTask &&) = default;
-        DBTask &operator=(const DBTask &) = delete;
-        DBTask &operator=(DBTask &&) = default;
-        void Run(sqlite3 *db);
+        ~Promise()
+        {
+            Reject();
+        }
+
+        Promise(const Promise &other) = delete;
+        Promise &operator=(const Promise &other) = delete;
+
+        ErrorHandler &GetErrorHandler() noexcept
+        {
+            return m_errorHandler;
+        }
+
+        template <typename TValue>
+        void Resolve(const TValue &value) noexcept
+        {
+            Complete([&] { m_onResolve(value); });
+        }
+
+        void Reject() noexcept
+        {
+            Complete([&] {
+                // Ensure that we have at least one error on rejection.
+                if (m_errorHandler.GetErrors().empty()) {
+                    m_errorHandler.AddError("Promise is rejected.");
+                }
+                m_onReject(m_errorHandler.GetErrors());
+            });
+        }
+
+        template <typename TValue>
+        void ResolveOrReject(const std::optional<TValue> &value) noexcept
+        {
+            if (value) {
+                Resolve(*value);
+            } else {
+                Reject();
+            }
+        }
 
     private:
-        Type m_type;
-        std::vector<winrt::Microsoft::ReactNative::JSValue> m_args;
-        Callback m_callback;
+        template <typename Fn>
+        void Complete(Fn &&fn)
+        {
+            if (m_isCompleted.test_and_set() == false) {
+                fn();
+            }
+        }
 
-        void multiGet(sqlite3 *db);
-        void multiSet(sqlite3 *db);
-        void multiRemove(sqlite3 *db);
-        void clear(sqlite3 *db);
-        void getAllKeys(sqlite3 *db);
+    private:
+        ErrorHandler m_errorHandler;
+        std::atomic_flag m_isCompleted{false};
+        TOnResolve m_onResolve;
+        TOnReject m_onReject;
     };
 
-    DBStorage();
+    // An asynchronous task that run in a background thread.
+    struct DBTask {
+        DBTask(ErrorHandler &errorHandler,
+               std::function<void(DBTask &task, sqlite3 *db)> &&onRun) noexcept;
+
+        DBTask() = default;
+        DBTask(const DBTask &) = delete;
+        DBTask &operator=(const DBTask &) = delete;
+
+        void Run(DBStorage &storage, sqlite3 *db) noexcept;
+        void Cancel() noexcept;
+
+        std::optional<std::vector<KeyValue>>
+        MultiGet(sqlite3 *db, const std::vector<std::string> &keys) noexcept;
+        std::optional<bool> MultiSet(sqlite3 *db, const std::vector<KeyValue> &keyValues) noexcept;
+        std::optional<bool> MultiMerge(sqlite3 *db,
+                                       const std::vector<KeyValue> &keyValues) noexcept;
+        std::optional<bool> MultiRemove(sqlite3 *db, const std::vector<std::string> &keys) noexcept;
+        std::optional<std::vector<std::string>> GetAllKeys(sqlite3 *db) noexcept;
+        std::optional<bool> RemoveAll(sqlite3 *db) noexcept;
+
+    private:
+        std::function<void(DBTask &task, sqlite3 *db)> m_onRun;
+        ErrorHandler &m_errorHandler;
+    };
+
+    using DatabasePtr = std::unique_ptr<sqlite3, decltype(&sqlite3_close)>;
+
+    std::optional<sqlite3 *> InitializeStorage(DBStorage::ErrorHandler &errorHandler) noexcept;
     ~DBStorage();
 
-    void AddTask(DBTask::Type type,
-                 std::vector<winrt::Microsoft::ReactNative::JSValue> &&args,
-                 Callback &&jsCallback);
-
-    void AddTask(DBTask::Type type, Callback &&jsCallback)
+    template <typename TOnResolve, typename TOnReject>
+    static auto CreatePromise(TOnResolve &&onResolve, TOnReject &&onReject) noexcept
     {
-        AddTask(type,
-                std::move(std::vector<winrt::Microsoft::ReactNative::JSValue>()),
-                std::move(jsCallback));
+        using PromiseType = Promise<std::decay_t<TOnResolve>, std::decay_t<TOnReject>>;
+        return std::make_shared<PromiseType>(std::forward<TOnResolve>(onResolve),
+                                             std::forward<TOnReject>(onReject));
     }
 
-    winrt::Windows::Foundation::IAsyncAction RunTasks();
+    void AddTask(ErrorHandler &errorHandler,
+                 std::function<void(DBStorage::DBTask &task, sqlite3 *db)> &&onRun) noexcept;
+
+    winrt::Windows::Foundation::IAsyncAction RunTasks() noexcept;
 
 private:
     static constexpr auto s_dbPathProperty = L"React-Native-Community-Async-Storage-Database-Path";
 
-    sqlite3 *m_db;
+    DatabasePtr m_db{nullptr, &sqlite3_close};
     winrt::slim_mutex m_lock;
     winrt::slim_condition_variable m_cv;
     winrt::Windows::Foundation::IAsyncAction m_action{nullptr};
-    std::vector<DBTask> m_tasks;
-
-    std::string ConvertWstrToStr(const std::wstring &wstr);
+    std::vector<std::unique_ptr<DBTask>> m_tasks;
 };
+
+void ReadValue(const winrt::Microsoft::ReactNative::IJSValueReader &reader,
+               /*out*/ DBStorage::KeyValue &value) noexcept;
+
+void WriteValue(const winrt::Microsoft::ReactNative::IJSValueWriter &writer,
+                const DBStorage::KeyValue &value) noexcept;
+
+void WriteValue(const winrt::Microsoft::ReactNative::IJSValueWriter &writer,
+                const DBStorage::Error &value) noexcept;

--- a/windows/code/RNCAsyncStorage.h
+++ b/windows/code/RNCAsyncStorage.h
@@ -1,175 +1,110 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 #pragma once
-
-#include "pch.h"
 
 #include "DBStorage.h"
 #include "NativeModules.h"
 
 namespace winrt::ReactNativeAsyncStorage::implementation
 {
-    REACT_MODULE(RNCAsyncStorage);
+    REACT_MODULE(RNCAsyncStorage)
     struct RNCAsyncStorage {
-        DBStorage dbStorage;
 
-        REACT_METHOD(multiGet);
-        void multiGet(std::vector<JSValue> keys,
-                      std::function<void(JSValueArray const &errors, JSValueArray const &results)>
-                          &&callback) noexcept
+        REACT_METHOD(multiGet)
+        void multiGet(
+            std::vector<std::string> &&keys,
+            std::function<void(const std::vector<DBStorage::Error> &errors,
+                               const std::vector<DBStorage::KeyValue> &result)> &&callback) noexcept
         {
-            dbStorage.AddTask(
-                DBStorage::DBTask::Type::multiGet,
-                std::move(keys),
-                [callback{std::move(callback)}](std::vector<JSValue> const &callbackParams) {
-                    if (callbackParams.size() > 0) {
-                        auto &errors = callbackParams[0].AsArray();
-                        if (callbackParams.size() > 1) {
-                            callback(errors, callbackParams[1].AsArray());
-                        } else {
-                            callback(errors, {});
-                        }
-                    }
+            auto promise = DBStorage::CreatePromise(
+                [callback](const std::vector<DBStorage::KeyValue> &result) {
+                    callback({}, result);
+                },
+                [callback](const std::vector<DBStorage::Error> &errors) { callback(errors, {}); });
+            m_dbStorage.AddTask(
+                promise->GetErrorHandler(),
+                [promise, keys = std::move(keys)](DBStorage::DBTask &task, sqlite3 *db) noexcept {
+                    promise->ResolveOrReject(task.MultiGet(db, keys));
                 });
         }
 
-        REACT_METHOD(multiSet);
-        void multiSet(std::vector<JSValue> pairs,
-                      std::function<void(JSValueArray const &)> &&callback) noexcept
+        REACT_METHOD(multiSet)
+        void multiSet(
+            std::vector<DBStorage::KeyValue> &&keyValues,
+            std::function<void(const std::vector<DBStorage::Error> &errors)> &&callback) noexcept
         {
-            dbStorage.AddTask(
-                DBStorage::DBTask::Type::multiSet,
-                std::move(pairs),
-                [callback{std::move(callback)}](std::vector<JSValue> const &callbackParams) {
-                    if (callbackParams.size() > 0) {
-                        auto &errors = callbackParams[0].AsArray();
-                        callback(errors);
-                    }
+            auto promise = DBStorage::CreatePromise(
+                [callback](bool /*value*/) { callback({}); },
+                [callback](const std::vector<DBStorage::Error> &errors) { callback(errors); });
+            m_dbStorage.AddTask(promise->GetErrorHandler(),
+                                [promise, keyValues = std::move(keyValues)](DBStorage::DBTask &task,
+                                                                            sqlite3 *db) noexcept {
+                                    promise->ResolveOrReject(task.MultiSet(db, keyValues));
+                                });
+        }
+
+        REACT_METHOD(multiMerge)
+        void multiMerge(
+            std::vector<DBStorage::KeyValue> &&keyValues,
+            std::function<void(const std::vector<DBStorage::Error> &errors)> &&callback) noexcept
+        {
+            auto promise = DBStorage::CreatePromise(
+                [callback](bool /*value*/) { callback({}); },
+                [callback](const std::vector<DBStorage::Error> &errors) { callback(errors); });
+            m_dbStorage.AddTask(promise->GetErrorHandler(),
+                                [promise, keyValues = std::move(keyValues)](DBStorage::DBTask &task,
+                                                                            sqlite3 *db) noexcept {
+                                    promise->ResolveOrReject(task.MultiMerge(db, keyValues));
+                                });
+        }
+
+        REACT_METHOD(multiRemove)
+        void multiRemove(
+            std::vector<std::string> &&keys,
+            std::function<void(const std::vector<DBStorage::Error> &errors)> &&callback) noexcept
+        {
+            auto promise = DBStorage::CreatePromise(
+                [callback](bool /*value*/) { callback({}); },
+                [callback](const std::vector<DBStorage::Error> &errors) { callback(errors); });
+            m_dbStorage.AddTask(
+                promise->GetErrorHandler(),
+                [promise, keys = std::move(keys)](DBStorage::DBTask &task, sqlite3 *db) noexcept {
+                    promise->ResolveOrReject(task.MultiRemove(db, keys));
                 });
         }
 
-        REACT_METHOD(multiMerge);
-        void multiMerge(std::vector<JSValue> pairs,
-                        std::function<void(JSValueArray const &)> &&callback) noexcept
+        REACT_METHOD(getAllKeys)
+        void
+        getAllKeys(std::function<void(const std::optional<DBStorage::Error> &error,
+                                      const std::vector<std::string> &keys)> &&callback) noexcept
         {
-            std::vector<JSValue> keys;
-            std::vector<std::string> newValues;
-            for (const auto &pair : pairs) {
-                keys.push_back(pair.AsArray()[0].AsString());
-                newValues.push_back(pair.AsArray()[1].AsString());
-            }
-
-            multiGet(std::move(keys),
-                     [newValues{std::move(newValues)}, callback{std::move(callback)}, this](
-                         JSValueArray const &errors, JSValueArray const &results) {
-                         if (errors.size() > 0) {
-                             callback(errors);
-                             return;
-                         }
-
-                         std::vector<JSValue> mergedResults;
-
-                         for (int i = 0; i < results.size(); i++) {
-                             auto &oldPair = results[i].AsArray();
-                             auto &key = oldPair[0];
-                             auto oldValue = oldPair[1].AsString();
-                             auto &newValue = newValues[i];
-
-                             winrt::Windows::Data::Json::JsonObject oldJson;
-                             winrt::Windows::Data::Json::JsonObject newJson;
-                             if (winrt::Windows::Data::Json::JsonObject::TryParse(
-                                     winrt::to_hstring(oldValue), oldJson) &&
-                                 winrt::Windows::Data::Json::JsonObject::TryParse(
-                                     winrt::to_hstring(newValue), newJson)) {
-                                 MergeJsonObjects(oldJson, newJson);
-
-                                 JSValue value;
-                                 auto writer = MakeJSValueTreeWriter();
-                                 writer.WriteArrayBegin();
-                                 WriteValue(writer, key);
-                                 WriteValue(writer, oldJson.ToString());
-                                 writer.WriteArrayEnd();
-                                 mergedResults.push_back(TakeJSValue(writer));
-                             } else {
-                                 auto writer = MakeJSValueTreeWriter();
-                                 writer.WriteObjectBegin();
-                                 WriteProperty(
-                                     writer, L"message", L"Values must be valid Json strings");
-                                 writer.WriteObjectEnd();
-                                 callback(JSValueArray{TakeJSValue(writer)});
-                                 return;
-                             }
-                         }
-
-                         multiSet(std::move(mergedResults),
-                                  [callback{std::move(callback)}](JSValueArray const &errors) {
-                                      callback(errors);
-                                  });
-                     });
-        }
-
-        REACT_METHOD(multiRemove);
-        void multiRemove(std::vector<JSValue> keys,
-                         std::function<void(JSValueArray const &)> &&callback) noexcept
-        {
-            dbStorage.AddTask(
-                DBStorage::DBTask::Type::multiRemove,
-                std::move(keys),
-                [callback{std::move(callback)}](std::vector<JSValue> const &callbackParams) {
-                    if (callbackParams.size() > 0) {
-                        auto &errors = callbackParams[0].AsArray();
-                        callback(errors);
-                    }
+            auto promise = DBStorage::CreatePromise(
+                [callback](const std::vector<std::string> &keys) { callback(std::nullopt, keys); },
+                [callback](const std::vector<DBStorage::Error> &errors) {
+                    callback(errors.at(0), {});
                 });
+            m_dbStorage.AddTask(promise->GetErrorHandler(),
+                                [promise](DBStorage::DBTask &task, sqlite3 *db) noexcept {
+                                    promise->ResolveOrReject(task.GetAllKeys(db));
+                                });
         }
 
-        REACT_METHOD(getAllKeys);
-        void getAllKeys(
-            std::function<void(JSValue const &error, JSValueArray const &keys)> &&callback) noexcept
+        REACT_METHOD(clear)
+        void
+        clear(std::function<void(const std::optional<DBStorage::Error> &error)> &&callback) noexcept
         {
-            dbStorage.AddTask(
-                DBStorage::DBTask::Type::getAllKeys,
-                [callback{std::move(callback)}](std::vector<JSValue> const &callbackParams) {
-                    if (callbackParams.size() > 0) {
-                        auto &error = callbackParams[0];
-                        if (callbackParams.size() > 1) {
-                            callback(error, callbackParams[1].AsArray());
-                        } else {
-                            callback(error, {});
-                        }
-                    }
-                });
+            auto promise =
+                DBStorage::CreatePromise([callback](bool /*value*/) { callback(std::nullopt); },
+                                         [callback](const std::vector<DBStorage::Error> &errors) {
+                                             callback(errors.at(0));
+                                         });
+            m_dbStorage.AddTask(promise->GetErrorHandler(),
+                                [promise](DBStorage::DBTask &task, sqlite3 *db) noexcept {
+                                    promise->ResolveOrReject(task.RemoveAll(db));
+                                });
         }
 
-        REACT_METHOD(clear);
-        void clear(std::function<void(JSValue const &)> &&callback) noexcept
-        {
-            dbStorage.AddTask(
-                DBStorage::DBTask::Type::clear,
-                [callback{std::move(callback)}](std::vector<JSValue> const &callbackParams) {
-                    if (callbackParams.size() > 0) {
-                        auto &error = callbackParams[0];
-                        callback(error);
-                    }
-                });
-        }
-
-        // Merge newJson into oldJson
-        void MergeJsonObjects(winrt::Windows::Data::Json::JsonObject const &oldJson,
-                              winrt::Windows::Data::Json::JsonObject const &newJson)
-        {
-            for (auto pair : newJson) {
-                auto key = pair.Key();
-                auto newValue = pair.Value();
-                if (newValue.ValueType() == winrt::Windows::Data::Json::JsonValueType::Object &&
-                    oldJson.HasKey(key)) {
-                    auto oldValue = oldJson.GetNamedObject(key);
-                    MergeJsonObjects(oldValue, newValue.GetObject());
-                    oldJson.SetNamedValue(key, oldValue);
-                } else {
-                    oldJson.SetNamedValue(key, newValue);
-                }
-            }
-        }
+    private:
+        DBStorage m_dbStorage;
     };
 }  // namespace winrt::ReactNativeAsyncStorage::implementation

--- a/windows/code/ReactPackageProvider.cpp
+++ b/windows/code/ReactPackageProvider.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 #include "pch.h"
 

--- a/windows/code/ReactPackageProvider.h
+++ b/windows/code/ReactPackageProvider.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 #pragma once
 

--- a/windows/code/pch.cpp
+++ b/windows/code/pch.cpp
@@ -1,3 +1,3 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 #include "pch.h"

--- a/windows/code/pch.h
+++ b/windows/code/pch.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 #pragma once
 


### PR DESCRIPTION
## Summary

Lately we saw a number of Watson crash reports in Windows that show crashes due to the result callbacks called twice in case if there are errors related to the database operations. The analysis has shown that the code has no protection from the callbacks being called twice and that the `multiMerge` method is not implemented in a safe way as other methods intended to be.

## Details
This PR is relatively big. It is almost a full rewrite of Windows module code. These are the changes:

- To ensure that the result callbacks are called exactly once (not more or less than once) we are adding `Promise` class that invokes the result callback when the `Promise` is resolved or rejected. To ensure that the callback is called not more than once, it uses `m_isCompleted` Boolean atomic variable. To ensure that the callback is called at least once, the `Reject` method is called from destructor.
- To implement strongly-typed module API, the new `KeyValue` and `Error` classes are added. These new types have custom `ReadValue` and `WriteValue` function overloads to convert to/from JSON. It allowed to stop using `JSValue` in favor of the strongly typed classes such as `std::vector`, `std::string`, `KeyValue`, and `Error`.
- The Database initialization is moved from constructor to the `InitializeStorage` method that allows to avoid using exceptions and to report errors the same way as other async task methods. This method is called on demand when a task started.
- All error reporting was changed to uniformly add errors to the error list associated with the `Promise` and indicate error result by the `std::nullopt` value. Most of all functions return `std::optional`.
- Convenience macros `CHECK` and `CHECK_SQL_OK` are added to simplify code by reducing `if-return` statements for each function call.
- `UniquePtrSetter` is added to allow natural use of `std::unique_ptr` for SQL object handlers.
- Since the updated `DBTask` is not copyable, the task list changed to hold `std::unique_ptr<DBTask` instances.
- Implemented `MultiMerge` method as other methods inside of `DBTask`. We needed to fix algorithm that matches keys between old and new values to use `std::unordered_set` instead of relying on their index which may be different and cause incorrect merges.
- Fixed `MergeJsonObjects` code to always check value type and that key exists.
- Cleaned up the `Sqlite3Transaction` class code.
- Fixed Microsoft copyright notice to follow the official company guidelines.

## Test Plan

The code is manually tested using the example app. The example app is generated using the following command:
```
yarn install-windows-test-app -p example/windows
```
