### PR TITLE
feat(types): remove `this` binding expectations on hook fn types

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -60,10 +60,10 @@ interface AsyncStorage {
 }
 
 type AsyncStorageHook = {
-  getItem(callback?: (error?: Error, result?: string) => void): Promise<string | null>;
-  setItem(value: string, callback?: (error?: Error) => void): Promise<void>;
-  mergeItem(value: string, callback?: (error?: Error) => void): Promise<void>;
-  removeItem(callback?: (error?: Error) => void): Promise<void>;
+  getItem(this: void, callback?: (error?: Error, result?: string) => void): Promise<string | null>;
+  setItem(this: void, value: string, callback?: (error?: Error) => void): Promise<void>;
+  mergeItem(this: void, value: string, callback?: (error?: Error) => void): Promise<void>;
+  removeItem(this: void, callback?: (error?: Error) => void): Promise<void>;
 }
 
 declare module '@react-native-async-storage/async-storage' {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -60,10 +60,10 @@ interface AsyncStorage {
 }
 
 type AsyncStorageHook = {
-  getItem(this: void, callback?: (error?: Error, result?: string) => void): Promise<string | null>;
-  setItem(this: void, value: string, callback?: (error?: Error) => void): Promise<void>;
-  mergeItem(this: void, value: string, callback?: (error?: Error) => void): Promise<void>;
-  removeItem(this: void, callback?: (error?: Error) => void): Promise<void>;
+  getItem: (callback?: (error?: Error, result?: string) => void) => Promise<string | null>;
+  setItem: (value: string, callback?: (error?: Error) => void) => Promise<void>;
+  mergeItem: (value: string, callback?: (error?: Error) => void) => Promise<void>;
+  removeItem: (callback?: (error?: Error) => void) => Promise<void>;
 }
 
 declare module '@react-native-async-storage/async-storage' {


### PR DESCRIPTION
## Summary

This change improves the experience for TypeScript users that have the [`unbound-method`](https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/docs/rules/unbound-method.md) eslint rule enabled. Without this change, check failures occur when users attempt to use destructured references to the functions returned in the `useAsyncStorage` hook's envelope object.

Example:

```typescript
const { getItem, setItem } = useAsyncStorage('someKey')

// eslint@typescript-eslint/unbound-method
//
// Avoid referencing unbound methods which may cause unintentional
// scoping of `this`. If your function does not access `this`, you can
// annotate it with `this: void`, or consider using an arrow function
// instead.
```

## Test Plan

This is a type change only, so no direct testing is applicable. However, the impacts of this typing change can be explored/tested in [this TypeScript playground here](https://www.typescriptlang.org/play?ts=4.5.4#code/C4TwDgpgBAggziAdgYwMrAPYCcCGBzCACQwwGsoBeKAbwCgooDgBJYCAWwApgALASzgAuKADcMfACYAaKMhwAbeQCMcyUgH5hnCFizZNUAKK7sMrBDgBXecANxgWPojwBKSgD5R4iS+EAFPXYBCAAee0dnKAAfKERreXcAbnooOAgWNi4RBUsIYXCnPBk5RRU1A20TLANjPSw3Ck8xSV8oAIwgtJDmiSSU9h0CVg5ObPlc-IdC4oVlVQ0tHTqaqoam71b2ztCevoZzdgwRCGGuErnyxaqVurWvFv9A4O7vPoBfWlpkDER7KAAzRCUKCcSxpeBINCYXAEYhkLR3CEodDYfBEEikO50BgMb6-YA0RjpU4yNIZDhQN7AsEQJFQ1GwjGcFwpBhMU6cSpYMwWO5LKDqKBLAB0AzgcDRUGE5jgLJxqWJmU4AHIxrllS5hbwIIhOXc8XAMPIIML5Bg8CrUOlRDloFZkMgLHB-vEQABCDUst5AA).

This change uses a feature supported even in really old versions of TypeScript, so it should not be considered a breaking change. Even the oldest version available in the TypeScript playground supports this change just fine. 
