### PR TITLE
chore: support RN 0.67

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "merge-options": "^3.0.4"
   },
   "peerDependencies": {
-    "react-native": "^0.0.0-0 || 0.60 - 0.66 || 1000.0.0"
+    "react-native": "^0.0.0-0 || 0.60 - 0.67 || 1000.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.12.0",


### PR DESCRIPTION
## Summary

Saw no breaking changes from RN 0.67, so adding support

Fixes https://github.com/react-native-async-storage/async-storage/issues/740