### PR TITLE
fix(useAsyncStorage): make more robust

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,4 @@ buck-out/
 
 # builds by bob
 lib/
+coverage

--- a/__tests__/useAsyncStorage.test.ts
+++ b/__tests__/useAsyncStorage.test.ts
@@ -1,0 +1,84 @@
+/**
+ * @format
+ */
+/* eslint-disable no-shadow */
+import { renderHook, act } from '@testing-library/react-hooks';
+
+import AsyncStorage, { useAsyncStorage } from '../src';
+
+afterEach(AsyncStorage.clear);
+
+function expectStableCallbacks(result: any, rerender: () => void) {
+  const previousFunctions = Object.values(result.current).filter(
+    (item) => typeof item === 'function'
+  );
+  rerender();
+  const nowFunctions = Object.values(result.current).filter(
+    (item) => typeof item === 'function'
+  );
+  expect(nowFunctions).toHaveLength(previousFunctions.length);
+  expect(nowFunctions).toEqual(previousFunctions);
+}
+
+describe('useAsyncStorage', () => {
+  it('should export only stable output', async () => {
+    const { result, rerender } = renderHook(() => useAsyncStorage('key'));
+    expect(result.error).toBeUndefined();
+    expectStableCallbacks(result, rerender);
+  });
+
+  it('can read/write data to/from storage', async () => {
+    const newData = Math.floor(Math.random() * 1000).toString();
+    const { result } = renderHook(() => useAsyncStorage('key'));
+
+    await result.current.setItem(newData);
+
+    const data = await result.current.getItem();
+
+    expect(data).toBe(newData);
+  });
+
+  it('can remove from storage', async () => {
+    await AsyncStorage.setItem('key', 'value');
+    const { result } = renderHook(() => useAsyncStorage('key'));
+    await act(() => result.current.removeItem());
+    expect(await AsyncStorage.getItem('key')).toBeNull();
+  });
+
+  it.skip('should throw when mergeItem is not supported', async () => {
+    const { result } = renderHook(() => useAsyncStorage('key'));
+    const mergeItem = AsyncStorage.mergeItem;
+    delete AsyncStorage.mergeItem;
+    expect(result.current.mergeItem({})).rejects.toThrow();
+    AsyncStorage.mergeItem = mergeItem;
+  });
+
+  it('can use merge with current data in storage', async () => {
+    let originalPerson = {
+      name: 'Jerry',
+      age: 21,
+      characteristics: {
+        hair: 'black',
+        eyes: 'green',
+      },
+    };
+
+    const { result } = renderHook(() => useAsyncStorage('person'));
+
+    await result.current.setItem(JSON.stringify(originalPerson));
+
+    originalPerson.name = 'Harry';
+    originalPerson.characteristics.hair = 'red';
+    // @ts-expect-error
+    originalPerson.characteristics.shoeSize = 40;
+
+    await result.current.mergeItem(JSON.stringify(originalPerson));
+
+    const currentPerson = await result.current.getItem();
+    const person = JSON.parse(currentPerson);
+
+    expect(person).toHaveProperty('name', 'Harry');
+    expect(person.characteristics).toHaveProperty('hair', 'red');
+    expect(person.characteristics).toHaveProperty('shoeSize', 40);
+  });
+});

--- a/__tests__/useAsyncStorage.test.ts
+++ b/__tests__/useAsyncStorage.test.ts
@@ -1,7 +1,6 @@
 /**
  * @format
  */
-/* eslint-disable no-shadow */
 import { renderHook, act } from '@testing-library/react-hooks';
 
 import AsyncStorage, { useAsyncStorage } from '../src';
@@ -45,7 +44,7 @@ describe('useAsyncStorage', () => {
     expect(await AsyncStorage.getItem('key')).toBeNull();
   });
 
-  it.skip('should throw when mergeItem is not supported', async () => {
+  it('should throw when mergeItem is not supported', async () => {
     const { result } = renderHook(() => useAsyncStorage('key'));
     const mergeItem = AsyncStorage.mergeItem;
     delete AsyncStorage.mergeItem;
@@ -81,4 +80,5 @@ describe('useAsyncStorage', () => {
     expect(person.characteristics).toHaveProperty('hair', 'red');
     expect(person.characteristics).toHaveProperty('shoeSize', 40);
   });
+});
 });

--- a/package.json
+++ b/package.json
@@ -74,6 +74,8 @@
     "@react-native-community/eslint-config": "^3.0.0",
     "@semantic-release/changelog": "^6.0.0",
     "@semantic-release/git": "^10.0.0",
+    "@testing-library/react-hooks": "^7.0.2",
+    "@types/jest": "^27.4.1",
     "@types/react": "^17.0.0",
     "@types/react-native": "^0.64.0",
     "concurrently": "^6.4.0",
@@ -99,10 +101,10 @@
     "npm/chalk": "^4.1.2"
   },
   "jest": {
-    "preset": "react-native",
     "setupFiles": [
       "./example/jest.setup.js"
-    ]
+    ],
+    "restoreMocks": true
   },
   "detox": {
     "test-runner": "jest",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "@semantic-release/changelog": "^6.0.0",
     "@semantic-release/git": "^10.0.0",
     "@testing-library/react-hooks": "^7.0.2",
-    "@types/jest": "^27.4.1",
+    "@types/jest": "^26.0.24",
     "@types/react": "^17.0.0",
     "@types/react-native": "^0.64.0",
     "concurrently": "^6.4.0",

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -8,15 +8,13 @@ export function useAsyncStorage(key: string) {
   );
 
   const setItem = React.useCallback(
-    //@ts-ignore
-    (...args) => AsyncStorage.setItem(key, ...args),
+    (...args: any[]) => AsyncStorage.setItem(key, args[0], args[1]),
     [key]
   );
 
   const mergeItem = React.useCallback(
     (...args) =>
-      //@ts-ignore
-      AsyncStorage.mergeItem?.(key, ...args) ??
+      AsyncStorage.mergeItem?.(key, args[0], args[1]) ??
       Promise.reject('Not implemented'),
     [key]
   );

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -1,13 +1,35 @@
+import React from 'react';
 import AsyncStorage from './AsyncStorage';
-import type { AsyncStorageHook } from './types';
 
-export function useAsyncStorage(key: string): AsyncStorageHook {
-  return {
-    getItem: (...args) => AsyncStorage.getItem(key, ...args),
-    setItem: (...args) => AsyncStorage.setItem(key, ...args),
-    mergeItem: (...args) =>
+export function useAsyncStorage(key: string) {
+  const getItem = React.useCallback(
+    (...args) => AsyncStorage.getItem(key, ...args),
+    [key]
+  );
+
+  const setItem = React.useCallback(
+    //@ts-ignore
+    (...args) => AsyncStorage.setItem(key, ...args),
+    [key]
+  );
+
+  const mergeItem = React.useCallback(
+    (...args) =>
+      //@ts-ignore
       AsyncStorage.mergeItem?.(key, ...args) ??
       Promise.reject('Not implemented'),
-    removeItem: (...args) => AsyncStorage.removeItem(key, ...args),
+    [key]
+  );
+
+  const removeItem = React.useCallback(
+    (...args) => AsyncStorage.removeItem(key, ...args),
+    [key]
+  );
+
+  return {
+    getItem,
+    setItem,
+    mergeItem,
+    removeItem,
   };
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1098,6 +1098,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.12.5":
+  version "7.17.2"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.17.2.tgz#66f68591605e59da47523c631416b18508779941"
+  integrity sha512-hzeyJyMA1YGdJTuWU0e/j4wKXrU4OMFvY2MSlaI9B7VQb0r5cxTE3EAIS2Q7Tn2RIcDkRvTA/v2JsAEhxe99uw==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/template@^7.0.0", "@babel/template@^7.16.7", "@babel/template@^7.3.3", "@babel/template@^7.8.6":
   version "7.16.7"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.16.7.tgz#8d126c8701fde4d66b264b3eba3d96f07666d155"
@@ -2275,6 +2282,17 @@
   dependencies:
     "@sinonjs/commons" "^1.7.0"
 
+"@testing-library/react-hooks@^7.0.2":
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/@testing-library/react-hooks/-/react-hooks-7.0.2.tgz#3388d07f562d91e7f2431a4a21b5186062ecfee0"
+  integrity sha512-dYxpz8u9m4q1TuzfcUApqi8iFfR6R0FaMbr2hjZJy1uC8z+bO/K4v8Gs9eogGKYQop7QsrBTFkv/BCF7MzD2Cg==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    "@types/react" ">=16.9.0"
+    "@types/react-dom" ">=16.9.0"
+    "@types/react-test-renderer" ">=16.9.0"
+    react-error-boundary "^3.1.0"
+
 "@tootallnate/once@1":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"
@@ -2357,6 +2375,14 @@
   dependencies:
     "@types/istanbul-lib-report" "*"
 
+"@types/jest@^27.4.1":
+  version "27.4.1"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-27.4.1.tgz#185cbe2926eaaf9662d340cc02e548ce9e11ab6d"
+  integrity sha512-23iPJADSmicDVrWk+HT58LMJtzLAnB2AgIzplQuq/bSrGaxCrlvRFjGbXmamnnk/mAmCdLStiGqggu28ocUyiw==
+  dependencies:
+    jest-matcher-utils "^27.0.0"
+    pretty-format "^27.0.0"
+
 "@types/json-schema@^7.0.5", "@types/json-schema@^7.0.7", "@types/json-schema@^7.0.8":
   version "7.0.9"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.9.tgz#97edc9037ea0c38585320b28964dde3b39e4660d"
@@ -2402,6 +2428,13 @@
   resolved "https://registry.yarnpkg.com/@types/q/-/q-1.5.5.tgz#75a2a8e7d8ab4b230414505d92335d1dcb53a6df"
   integrity sha512-L28j2FcJfSZOnL1WBjDYp2vUHCeIFlyYI/53EwD/rKUBQ7MtUUfbQWiyKJGpcnv4/WgrhWsFKrcPstcAt/J0tQ==
 
+"@types/react-dom@>=16.9.0":
+  version "17.0.11"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-17.0.11.tgz#e1eadc3c5e86bdb5f7684e00274ae228e7bcc466"
+  integrity sha512-f96K3k+24RaLGVu/Y2Ng3e1EbZ8/cVJvypZWd7cy0ofCBaf2lcM46xNhycMZ2xGwbBjRql7hOlZ+e2WlJ5MH3Q==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react-native@^0.64.0":
   version "0.64.19"
   resolved "https://registry.yarnpkg.com/@types/react-native/-/react-native-0.64.19.tgz#2b888c082ad293fa0fa6ae34c5e9457cfb38e50a"
@@ -2409,10 +2442,26 @@
   dependencies:
     "@types/react" "*"
 
+"@types/react-test-renderer@>=16.9.0":
+  version "17.0.1"
+  resolved "https://registry.yarnpkg.com/@types/react-test-renderer/-/react-test-renderer-17.0.1.tgz#3120f7d1c157fba9df0118dae20cb0297ee0e06b"
+  integrity sha512-3Fi2O6Zzq/f3QR9dRnlnHso9bMl7weKCviFmfF6B4LS1Uat6Hkm15k0ZAQuDz+UBq6B3+g+NM6IT2nr5QgPzCw==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react@*", "@types/react@^17.0.0":
   version "17.0.37"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.37.tgz#6884d0aa402605935c397ae689deed115caad959"
   integrity sha512-2FS1oTqBGcH/s0E+CjrCCR9+JMpsu9b69RTFO+40ua43ZqP5MmQ4iUde/dMjWR909KxZwmOQIFq6AV6NjEG5xg==
+  dependencies:
+    "@types/prop-types" "*"
+    "@types/scheduler" "*"
+    csstype "^3.0.2"
+
+"@types/react@>=16.9.0":
+  version "17.0.39"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.39.tgz#d0f4cde092502a6db00a1cded6e6bf2abb7633ce"
+  integrity sha512-UVavlfAxDd/AgAacMa60Azl7ygyQNRwC/DsHZmKgNvPmRR5p70AJ5Q9EAmL2NWOJmeV+vVUI4IAP7GZrN8h8Ug==
   dependencies:
     "@types/prop-types" "*"
     "@types/scheduler" "*"
@@ -2921,6 +2970,11 @@ ansi-styles@^4.0.0, ansi-styles@^4.1.0, ansi-styles@^4.3.0:
   integrity sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==
   dependencies:
     color-convert "^2.0.1"
+
+ansi-styles@^5.0.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-5.2.0.tgz#07449690ad45777d1924ac2abb2fc8895dba836b"
+  integrity sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==
 
 ansicolors@~0.3.2:
   version "0.3.2"
@@ -4990,6 +5044,11 @@ diff-sequences@^26.6.2:
   version "26.6.2"
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-26.6.2.tgz#48ba99157de1923412eed41db6b6d4aa9ca7c0b1"
   integrity sha512-Mv/TDa3nZ9sbc5soK+OoA74BsS3mL37yixCvUAQkiuA4Wz6YtwP/K47n2rv2ovzHZvoiQeA5FTQOschKkEwB0Q==
+
+diff-sequences@^27.5.1:
+  version "27.5.1"
+  resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-27.5.1.tgz#eaecc0d327fd68c8d9672a1e64ab8dccb2ef5327"
+  integrity sha512-k1gCAXAsNgLwEL+Y8Wvl+M6oEFj5bgazfZULpS5CneoPPXRaCCW7dm+q21Ky2VEE5X+VeRDBVg1Pcvvsr4TtNQ==
 
 diff@^5.0.0:
   version "5.0.0"
@@ -7559,6 +7618,16 @@ jest-diff@^26.6.2:
     jest-get-type "^26.3.0"
     pretty-format "^26.6.2"
 
+jest-diff@^27.5.1:
+  version "27.5.1"
+  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-27.5.1.tgz#a07f5011ac9e6643cf8a95a462b7b1ecf6680def"
+  integrity sha512-m0NvkX55LDt9T4mctTEgnZk3fmEg3NRYutvMPWM/0iPnkFj2wIeF45O1718cMSOFO1vINkqmxqD8vE37uTEbqw==
+  dependencies:
+    chalk "^4.0.0"
+    diff-sequences "^27.5.1"
+    jest-get-type "^27.5.1"
+    pretty-format "^27.5.1"
+
 jest-docblock@^26.0.0:
   version "26.0.0"
   resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-26.0.0.tgz#3e2fa20899fc928cb13bd0ff68bd3711a36889b5"
@@ -7606,6 +7675,11 @@ jest-get-type@^26.3.0:
   version "26.3.0"
   resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-26.3.0.tgz#e97dc3c3f53c2b406ca7afaed4493b1d099199e0"
   integrity sha512-TpfaviN1R2pQWkIihlfEanwOXK0zcxrKEE4MlU6Tn7keoXdN6/3gK/xl0yEh8DOunn5pOVGKf8hB4R9gVh04ig==
+
+jest-get-type@^27.5.1:
+  version "27.5.1"
+  resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-27.5.1.tgz#3cd613c507b0f7ace013df407a1c1cd578bcb4f1"
+  integrity sha512-2KY95ksYSaK7DMBWQn6dQz3kqAf3BB64y2udeG+hv4KfSOb9qwcYQstTJc1KCbsix+wLZWZYN8t7nwX3GOBLRw==
 
 jest-haste-map@^26.5.2, jest-haste-map@^26.6.2:
   version "26.6.2"
@@ -7669,6 +7743,16 @@ jest-matcher-utils@^26.6.2:
     jest-diff "^26.6.2"
     jest-get-type "^26.3.0"
     pretty-format "^26.6.2"
+
+jest-matcher-utils@^27.0.0:
+  version "27.5.1"
+  resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-27.5.1.tgz#9c0cdbda8245bc22d2331729d1091308b40cf8ab"
+  integrity sha512-z2uTx/T6LBaCoNWNFWwChLBKYxTMcGBRjAt+2SbP929/Fflb9aa5LGma654Rz8z9HLxsrUaYzxE9T/EFIL/PAw==
+  dependencies:
+    chalk "^4.0.0"
+    jest-diff "^27.5.1"
+    jest-get-type "^27.5.1"
+    pretty-format "^27.5.1"
 
 jest-message-util@^26.6.2:
   version "26.6.2"
@@ -10847,6 +10931,15 @@ pretty-format@^26.4.0, pretty-format@^26.5.2, pretty-format@^26.6.2:
     ansi-styles "^4.0.0"
     react-is "^17.0.1"
 
+pretty-format@^27.0.0, pretty-format@^27.5.1:
+  version "27.5.1"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-27.5.1.tgz#2181879fdea51a7a5851fb39d920faa63f01d88e"
+  integrity sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==
+  dependencies:
+    ansi-regex "^5.0.1"
+    ansi-styles "^5.0.0"
+    react-is "^17.0.1"
+
 proc-log@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/proc-log/-/proc-log-1.0.0.tgz#0d927307401f69ed79341e83a0b2c9a13395eb77"
@@ -11135,6 +11228,13 @@ react-dom@17.0.2:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
     scheduler "^0.20.2"
+
+react-error-boundary@^3.1.0:
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/react-error-boundary/-/react-error-boundary-3.1.4.tgz#255db92b23197108757a888b01e5b729919abde0"
+  integrity sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
 
 react-error-overlay@^6.0.9:
   version "6.0.9"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1091,10 +1091,10 @@
     pirates "^4.0.0"
     source-map-support "^0.5.16"
 
-"@babel/runtime@^7.0.0", "@babel/runtime@^7.14.0", "@babel/runtime@^7.8.4":
-  version "7.16.3"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.16.3.tgz#b86f0db02a04187a3c17caa77de69840165d42d5"
-  integrity sha512-WBwekcqacdY2e9AF/Q7WLFUWmdJGJTkbjqTjoMDgXkVZ3ZRUvOPsLb5KdwISoQVsbP+DQzVZW4Zhci0DvpbNTQ==
+"@babel/runtime@^7.0.0", "@babel/runtime@^7.12.5", "@babel/runtime@^7.14.0", "@babel/runtime@^7.8.4":
+  version "7.17.2"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.17.2.tgz#66f68591605e59da47523c631416b18508779941"
+  integrity sha512-hzeyJyMA1YGdJTuWU0e/j4wKXrU4OMFvY2MSlaI9B7VQb0r5cxTE3EAIS2Q7Tn2RIcDkRvTA/v2JsAEhxe99uw==
   dependencies:
     regenerator-runtime "^0.13.4"
 
@@ -2375,13 +2375,13 @@
   dependencies:
     "@types/istanbul-lib-report" "*"
 
-"@types/jest@^27.4.1":
-  version "27.4.1"
-  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-27.4.1.tgz#185cbe2926eaaf9662d340cc02e548ce9e11ab6d"
-  integrity sha512-23iPJADSmicDVrWk+HT58LMJtzLAnB2AgIzplQuq/bSrGaxCrlvRFjGbXmamnnk/mAmCdLStiGqggu28ocUyiw==
+"@types/jest@^26.0.24":
+  version "26.0.24"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-26.0.24.tgz#943d11976b16739185913a1936e0de0c4a7d595a"
+  integrity sha512-E/X5Vib8BWqZNRlDxj9vYXhsDwPYbPINqKF9BsnSoon4RQ0D9moEuLD8txgyypFLH7J4+Lho9Nr/c8H0Fi+17w==
   dependencies:
-    jest-matcher-utils "^27.0.0"
-    pretty-format "^27.0.0"
+    jest-diff "^26.0.0"
+    pretty-format "^26.0.0"
 
 "@types/json-schema@^7.0.5", "@types/json-schema@^7.0.7", "@types/json-schema@^7.0.8":
   version "7.0.9"
@@ -2449,10 +2449,10 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@^17.0.0":
-  version "17.0.37"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.37.tgz#6884d0aa402605935c397ae689deed115caad959"
-  integrity sha512-2FS1oTqBGcH/s0E+CjrCCR9+JMpsu9b69RTFO+40ua43ZqP5MmQ4iUde/dMjWR909KxZwmOQIFq6AV6NjEG5xg==
+"@types/react@*", "@types/react@>=16.9.0", "@types/react@^17.0.0":
+  version "17.0.39"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.39.tgz#d0f4cde092502a6db00a1cded6e6bf2abb7633ce"
+  integrity sha512-UVavlfAxDd/AgAacMa60Azl7ygyQNRwC/DsHZmKgNvPmRR5p70AJ5Q9EAmL2NWOJmeV+vVUI4IAP7GZrN8h8Ug==
   dependencies:
     "@types/prop-types" "*"
     "@types/scheduler" "*"
@@ -7608,7 +7608,7 @@ jest-config@^26.6.3:
     micromatch "^4.0.2"
     pretty-format "^26.6.2"
 
-jest-diff@^26.6.2:
+jest-diff@^26.0.0, jest-diff@^26.6.2:
   version "26.6.2"
   resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-26.6.2.tgz#1aa7468b52c3a68d7d5c5fdcdfcd5e49bd164394"
   integrity sha512-6m+9Z3Gv9wN0WFVasqjCL/06+EFCMTqDEUl/b87HYK2rAPTyfz4ZIuSlPhY51PIQRWx5TaxeF1qmXKe9gfN3sA==
@@ -10921,7 +10921,7 @@ pretty-error@^2.1.1:
     lodash "^4.17.20"
     renderkid "^2.0.4"
 
-pretty-format@^26.4.0, pretty-format@^26.5.2, pretty-format@^26.6.2:
+pretty-format@^26.0.0, pretty-format@^26.4.0, pretty-format@^26.5.2, pretty-format@^26.6.2:
   version "26.6.2"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-26.6.2.tgz#e35c2705f14cb7fe2fe94fa078345b444120fc93"
   integrity sha512-7AeGuCYNGmycyQbCqd/3PWH4eOoX/OiCa0uphp57NVTeAGdJGaAliecxwBDHYQCIvrW7aDBZCYeNTP/WX69mkg==


### PR DESCRIPTION
## Summary

Fixes the broken `useAsyncStorage` and introduces a new `useAsyncStorageValue` as a true hook replacement.

I think we should not change the signature of useAsyncStorage for now in a patch release.
In this patch release we could also already introduce the new `useAsyncStorageValue` which will be renamed to `useAsyncStorage` in the next major version.

I'll also add `watch` support to make the hook truly magic and work across multiple components.
I'll first add the watch support to the hooks infrastructure only, that means any changes done by AsyncStorage.setXXX/mergeXXX are not detected. But when one only uses the hooks, then changes in values are propagated into each hook.


## Test Plan

`yarn jest __tests___` for now.