### PR TITLE
ci: bump react-native-test-app to 1.1.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "react-native": "^0.64.0",
     "react-native-builder-bob": "^0.18.0",
     "react-native-macos": "^0.64.0",
-    "react-native-test-app": "^1.1.2",
+    "react-native-test-app": "^1.1.4",
     "react-native-web": "^0.17.0",
     "react-native-windows": "^0.64.0",
     "react-test-renderer": "17.0.1",

--- a/scripts/ios_e2e.sh
+++ b/scripts/ios_e2e.sh
@@ -5,11 +5,6 @@ ENTRY_FILE="example/index.ts"
 BUNDLE_FILE="$RESOURCE_DIR/main.jsbundle"
 EXTRA_PACKAGER_ARGS="--entry-file=$ENTRY_FILE"
 SIMULATOR_NAME="iPhone 13"
-IOS_XCSCHEME="node_modules/.generated/ios/ReactTestApp.xcodeproj/xcshareddata/xcschemes/ReactTestApp.xcscheme"
-
-# Disable Address Sanitizer as it crashes Detox
-sed -i '' 's/enableAddressSanitizer = "YES"/enableAddressSanitizer = "NO"/g' "$IOS_XCSCHEME"
-sed -i '' 's/enableUBSanitizer = "YES"/enableUBSanitizer = "NO"/g' "$IOS_XCSCHEME"
 
 build_project() {
   echo "[Detox e2e] Building iOS project"

--- a/yarn.lock
+++ b/yarn.lock
@@ -11147,10 +11147,10 @@ react-native-macos@^0.64.0:
     whatwg-fetch "^3.0.0"
     ws "^6.1.4"
 
-react-native-test-app@^1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/react-native-test-app/-/react-native-test-app-1.1.2.tgz#e0a102b7cce05bc79c11d85b72f8222d7ee3a5e8"
-  integrity sha512-yLh6YZTQlMncuwN+C4i0TCNc/KR+t0/fwI9Roivy2/efmTDJW6moEKA0r/UgLvNQ+R3eXy9c5Utc2EdgyTXtMw==
+react-native-test-app@^1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/react-native-test-app/-/react-native-test-app-1.1.4.tgz#a959e5d847079cbaa290c6ef6174db52ecadcac5"
+  integrity sha512-DiMCRgVEJn9WS0oefwIxdb4aylTAfx6kKf+E6G1xRS/fZN3zR7BwQ7eVsihtijESi9BL2kAjF7LHU79uAUZNlQ==
   dependencies:
     ajv "^8.0.0"
     chalk "^4.1.0"


### PR DESCRIPTION
## Summary

Bumps react-native-test-app to 1.1.4 to fix issues with Address and Undefined Behavior sanitizers.

## Test Plan

CI should pass.