### PR TITLE
Update types.ts to fix wrong void return type of multiGet

### DIFF
--- a/src/AsyncStorage.native.ts
+++ b/src/AsyncStorage.native.ts
@@ -269,7 +269,7 @@ const AsyncStorage = ((): AsyncStorageStatic => {
         reject: null as any,
       };
 
-      const promiseResult = new Promise<readonly KeyValuePair[] | void>(
+      const promiseResult = new Promise<readonly KeyValuePair[]>(
         (resolve, reject) => {
           getRequest.resolve = resolve;
           getRequest.reject = reject;

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,7 +23,7 @@ export type MultiRequest = {
   keys: readonly string[];
   callback?: MultiGetCallback;
   keyIndex: number;
-  resolve?: (result?: readonly KeyValuePair[]) => void;
+  resolve?: (result: readonly KeyValuePair[]) => void;
   reject?: (error?: any) => void;
 };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -125,7 +125,7 @@ export type AsyncStorageStatic = {
   multiGet: (
     keys: string[],
     callback?: MultiGetCallback
-  ) => Promise<readonly KeyValuePair[] | void>;
+  ) => Promise<readonly KeyValuePair[]>;
 
   /**
    * Use this as a batch operation for storing multiple key-value pairs. When


### PR DESCRIPTION
Fix https://github.com/react-native-async-storage/async-storage/issues/764

## Summary

<!--
  Thank you for submitting a PR!

  Help us understand more of your work - you can explain what you did, post a
  link to an issue, screenshots etc. Anything helps!
-->

## Test Plan

<!--
    Help us test your work (**REQUIRED**).

    If you changed the code, please provide us with instructions of how we can
    try it out ourselves, so we can confirm it's working. You can also post
    screenshots/gifts.
-->
