### PR TITLE
fix(windows): fix MultiRemove by using CHECK_SQL_OK macro

### DIFF
--- a/windows/code/DBStorage.cpp
+++ b/windows/code/DBStorage.cpp
@@ -521,7 +521,7 @@ std::optional<bool> DBStorage::DBTask::MultiRemove(sqlite3 *db,
     auto statement = StatementPtr{nullptr, &sqlite3_finalize};
     CHECK_SQL_OK(PrepareStatement(db, sql, &statement));
     for (int i = 0; i < argCount; i++) {
-        CHECK(BindString(statement, i + 1, keys[i]));
+        CHECK_SQL_OK(BindString(statement, i + 1, keys[i]));
     }
     for (;;) {
         auto stepResult = sqlite3_step(statement.get());


### PR DESCRIPTION
## Summary

Resolves #755 
In the `MultiRemove` we used a wrong macro `CHECK` instead of `CHECK_SQL_OK` which was failing in successful cases.

## Test Plan

Tested manually.
To test manually we run the following commands:
- `yarn install-windows-test-app -p example/windows`
- run `yarn start` in the `example\windows` folder
- open and debug AsyncStorageExample.sln in the `example\windows` folder
