### PR TITLE
Bump room to 2.4.2, allowing arm64 jdk compile

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -39,7 +39,7 @@ buildscript {
             ? rootProject.ext['kotlinVersion']
             : rootProject.hasProperty('AsyncStorage_kotlinVersion')
             ? rootProject.properties['AsyncStorage_kotlinVersion']
-            : '1.5.31'
+            : '1.6.10'
 
     repositories {
         google()
@@ -97,9 +97,6 @@ android {
             sourceCompatibility JavaVersion.VERSION_1_8
             targetCompatibility JavaVersion.VERSION_1_8
         }
-        kotlinOptions {
-            jvmTarget = "1.8"
-        }
     }
 }
 
@@ -116,8 +113,8 @@ dependencies {
 
     if (useNextStorage) {
         def room_version = getVersionOrDefault('AsyncStorage_next_roomVersion', '2.4.2')
-        def coroutines_version = "1.5.2"
-        def coroutinesTest_version = "1.5.2"
+        def coroutines_version = "1.6.0"
+        def coroutinesTest_version = "1.6.0"
         // if we don't provide explicit dependency on reflection, kotlin plugin
         // would add one automatically, probably a version that is not compatible with
         // used kotlin

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -77,10 +77,10 @@ if (useNextStorage) {
 }
 
 android {
-    compileSdkVersion safeExtGet('compileSdkVersion', 28)
+    compileSdkVersion safeExtGet('compileSdkVersion', 31)
     defaultConfig {
-        minSdkVersion safeExtGet('minSdkVersion', 19)
-        targetSdkVersion safeExtGet('targetSdkVersion', 28)
+        minSdkVersion safeExtGet('minSdkVersion', 21)
+        targetSdkVersion safeExtGet('targetSdkVersion', 29)
         buildConfigField "Long", "AsyncStorage_db_size", "${dbSizeInMB}L"
         buildConfigField "boolean", "AsyncStorage_useDedicatedExecutor", "${useDedicatedExecutor}"
         buildConfigField "boolean", "AsyncStorage_useNextStorage", "${useNextStorage}"

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -115,7 +115,7 @@ repositories {
 dependencies {
 
     if (useNextStorage) {
-        def room_version = getVersionOrDefault('AsyncStorage_next_roomVersion', '2.3.0')
+        def room_version = getVersionOrDefault('AsyncStorage_next_roomVersion', '2.4.2')
         def coroutines_version = "1.5.2"
         def coroutinesTest_version = "1.5.2"
         // if we don't provide explicit dependency on reflection, kotlin plugin

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "react-native": "^0.66.0-0",
     "react-native-builder-bob": "^0.18.0",
     "react-native-macos": "^0.66.0-0",
-    "react-native-test-app": "^1.2.0",
+    "react-native-test-app": "^1.2.1",
     "react-native-web": "^0.17.0",
     "react-native-windows": "^0.66.0-0",
     "react-test-renderer": "17.0.2",

--- a/website/docs/advanced/Next.md
+++ b/website/docs/advanced/Next.md
@@ -85,10 +85,10 @@ AsyncStorage_kotlinVersion=1.5.31
 **Room**
 
 Next AsyncStorage uses [Room persistence library](https://developer.android.com/jetpack/androidx/releases/room) to store data.
-Currently, tested version is `2.3.0`. You can specify different version, by adding a flag to `gradle.properties`:
+Currently, tested version is `2.4.2`. You can specify different version, by adding a flag to `gradle.properties`:
 
 ```groovy
-AsyncStorage_next_roomVersion=2.3.0
+AsyncStorage_next_roomVersion=2.4.2
 ```
 
 ### Notable changes

--- a/website/docs/advanced/Next.md
+++ b/website/docs/advanced/Next.md
@@ -46,7 +46,7 @@ See [Configuration](#configuration) section below to learn more about setting di
 buildscript {
     ext {
         // other extensions
-+        kotlinVersion = '1.5.31'
++        kotlinVersion = '1.6.10'
     }
     
     dependencies {
@@ -67,19 +67,19 @@ AsyncStorage_useNextStorage=true
 
 **Kotlin version**
 
-Next storage is tested against Kotlin version `1.5.31`. 
+Next storage is tested against Kotlin version `1.6.10`. 
 You can specify different version, in one of two ways:
 
 - add `kotlinVersion` extension to the `rootProject`:
 
 ```groovy
-rootProject.ext.kotlinVersion = '1.5.31'
+rootProject.ext.kotlinVersion = '1.6.10'
 ```
 
 - specify `AsyncStorage_kotlinVersion` in `gradle.properties`:
 
 ```groovy
-AsyncStorage_kotlinVersion=1.5.31
+AsyncStorage_kotlinVersion=1.6.10
 ```
 
 **Room**

--- a/yarn.lock
+++ b/yarn.lock
@@ -11224,10 +11224,10 @@ react-native-macos@^0.66.0-0:
     whatwg-fetch "^3.0.0"
     ws "^6.1.4"
 
-react-native-test-app@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/react-native-test-app/-/react-native-test-app-1.2.0.tgz#4f50a03df02ec735aaa87a00b5f494a383b3c486"
-  integrity sha512-6dVWeFluY9sDVKBNrR8lfX5jxTtxX1/Bcr/q1806280eomnEi3uVRt75wB2zcxZ8Kv+zEyujgYfjl7weCfBSQg==
+react-native-test-app@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/react-native-test-app/-/react-native-test-app-1.2.1.tgz#1dcf1b3be57689b185e019eced91223d274bbe2e"
+  integrity sha512-+M0cps3k95JNdCvcrq2sXmblAOzG/Zv/6xU100kRS/wn5lL/3MHTkKq/0+BKiLB/ov5iHozGcB+Sn3FqezTuhw==
   dependencies:
     ajv "^8.0.0"
     chalk "^4.1.0"


### PR DESCRIPTION
## Summary

Starting with room 2.4.0-alpha03 arm64 is supported allowing native compile with a arm64 jdk.

## Test Plan

1. Get yourself an m1
2. brew tap mdogan/zulu
3. brew install --cask zulu-jdk11
4. java -version (make sure you are running zulu)
5. any repo with rn and async-storage included
6. react-native run android (build will fail)
7. apply patch
8. react-native run android (build will succeed)
