### PR TITLE
fix(android): Bump test dependencies to support jdk17

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -47,7 +47,7 @@ buildscript {
     }
     dependencies {
         if (project == rootProject) {
-            classpath 'com.android.tools.build:gradle:3.6.4'
+            classpath 'com.android.tools.build:gradle:4.2.2'
             classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$asyncStorageKtVersion"
         }
     }
@@ -80,7 +80,7 @@ android {
     compileSdkVersion safeExtGet('compileSdkVersion', 31)
     defaultConfig {
         minSdkVersion safeExtGet('minSdkVersion', 21)
-        targetSdkVersion safeExtGet('targetSdkVersion', 29)
+        targetSdkVersion safeExtGet('targetSdkVersion', 31)
         buildConfigField "Long", "AsyncStorage_db_size", "${dbSizeInMB}L"
         buildConfigField "boolean", "AsyncStorage_useDedicatedExecutor", "${useDedicatedExecutor}"
         buildConfigField "boolean", "AsyncStorage_useNextStorage", "${useNextStorage}"
@@ -91,11 +91,10 @@ android {
 
     if (useNextStorage) {
         testOptions {
-            unitTests.returnDefaultValues = true
-        }
-        compileOptions {
-            sourceCompatibility JavaVersion.VERSION_1_8
-            targetCompatibility JavaVersion.VERSION_1_8
+            unitTests {
+                returnDefaultValues = true
+                includeAndroidResources = true
+            }
         }
     }
 }
@@ -119,8 +118,8 @@ dependencies {
         // would add one automatically, probably a version that is not compatible with
         // used kotlin
         def kotlinReflect_version = project.ext.asyncStorageKtVersion
-        def junit_version = "4.12"
-        def robolectric_version = "4.5.1"
+        def junit_version = "4.13.2"
+        def robolectric_version = "4.7.3"
         def truth_version = "1.1.2"
         def androidxtest_version = "1.1.0"
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -120,8 +120,9 @@ dependencies {
         def kotlinReflect_version = project.ext.asyncStorageKtVersion
         def junit_version = "4.13.2"
         def robolectric_version = "4.7.3"
-        def truth_version = "1.1.2"
-        def androidxtest_version = "1.1.0"
+        def truth_version = "1.1.3"
+        def androidxtest_version = "1.4.0"
+        def androidtest_junit_version = "1.1.3"
 
         implementation "androidx.room:room-runtime:$room_version"
         implementation "androidx.room:room-ktx:$room_version"
@@ -133,7 +134,7 @@ dependencies {
         testImplementation "junit:junit:$junit_version"
         testImplementation "androidx.test:runner:$androidxtest_version"
         testImplementation "androidx.test:rules:$androidxtest_version"
-        testImplementation "androidx.test.ext:junit:$androidxtest_version"
+        testImplementation "androidx.test.ext:junit:$androidtest_junit_version"
         testImplementation "org.robolectric:robolectric:$robolectric_version"
         testImplementation "com.google.truth:truth:$truth_version"
         testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:$coroutinesTest_version"

--- a/android/src/test/java/com/reactnativecommunity/asyncstorage/next/StorageTest.kt
+++ b/android/src/test/java/com/reactnativecommunity/asyncstorage/next/StorageTest.kt
@@ -129,11 +129,11 @@ class AsyncStorageAccessTest {
        "key2":"value2",
        "key3":{
           "key4":"value4",
-          "key5":"value5",
           "key6":{
              "key7":"value7",
              "key8":"value8"
-          }
+          },
+          "key5":"value5"
        }
     }
 """.trimMargin()


### PR DESCRIPTION
## Summary

Bumping dependencies for tests, to support jdk17.

## Test Plan

Green CI.
