### PR TITLE
fix: cannot find `react-native-test-app` when Metro starts

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "react-native": "^0.66.0-0",
     "react-native-builder-bob": "^0.18.0",
     "react-native-macos": "^0.66.0-0",
-    "react-native-test-app": "^1.3.2",
+    "react-native-test-app": "^1.3.4",
     "react-native-web": "^0.17.0",
     "react-native-windows": "^0.66.0-0",
     "react-test-renderer": "17.0.2",

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "react-native": "^0.66.0-0",
     "react-native-builder-bob": "^0.18.0",
     "react-native-macos": "^0.66.0-0",
-    "react-native-test-app": "^1.2.1",
+    "react-native-test-app": "^1.3.2",
     "react-native-web": "^0.17.0",
     "react-native-windows": "^0.66.0-0",
     "react-test-renderer": "17.0.2",

--- a/react-native.config.js
+++ b/react-native.config.js
@@ -1,10 +1,32 @@
-const fs = require('fs');
-const path = require('path');
-const {
-  androidManifestPath,
-  iosProjectPath,
-  windowsProjectPath,
-} = require('react-native-test-app');
+const project = (() => {
+  const fs = require('fs');
+  const path = require('path');
+  try {
+    const {
+      androidManifestPath,
+      iosProjectPath,
+      windowsProjectPath,
+    } = require('react-native-test-app');
+    return {
+      android: {
+        sourceDir: path.join('example', 'android'),
+        manifestPath: androidManifestPath(
+          path.join(__dirname, 'example', 'android')
+        ),
+      },
+      ios: {
+        project: iosProjectPath('example/ios'),
+      },
+      windows: fs.existsSync('example/windows/AsyncStorageExample.sln') && {
+        sourceDir: path.join('example', 'windows'),
+        solutionFile: 'AsyncStorageExample.sln',
+        project: windowsProjectPath(path.join(__dirname, 'example', 'windows')),
+      },
+    };
+  } catch (_) {
+    return undefined;
+  }
+})();
 
 module.exports = {
   dependencies: {
@@ -35,20 +57,5 @@ module.exports = {
       },
     },
   },
-  project: {
-    android: {
-      sourceDir: path.join('example', 'android'),
-      manifestPath: androidManifestPath(
-        path.join(__dirname, 'example', 'android')
-      ),
-    },
-    ios: {
-      project: iosProjectPath('example/ios'),
-    },
-    windows: fs.existsSync('example/windows/AsyncStorageExample.sln') && {
-      sourceDir: path.join('example', 'windows'),
-      solutionFile: 'AsyncStorageExample.sln',
-      project: windowsProjectPath(path.join(__dirname, 'example', 'windows')),
-    },
-  },
+  ...(project ? { project } : undefined),
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -11224,10 +11224,10 @@ react-native-macos@^0.66.0-0:
     whatwg-fetch "^3.0.0"
     ws "^6.1.4"
 
-react-native-test-app@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/react-native-test-app/-/react-native-test-app-1.2.1.tgz#1dcf1b3be57689b185e019eced91223d274bbe2e"
-  integrity sha512-+M0cps3k95JNdCvcrq2sXmblAOzG/Zv/6xU100kRS/wn5lL/3MHTkKq/0+BKiLB/ov5iHozGcB+Sn3FqezTuhw==
+react-native-test-app@^1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/react-native-test-app/-/react-native-test-app-1.3.2.tgz#9b01389712aff0b0568a0cae6beaeb5323052351"
+  integrity sha512-bRfe3vzH2LilfPgpDC1BZy6GRUWHfJOjRlDYu/B3J1acUCjxxnBle8f/anrNbu4TRL2au7/5zqIkUWXTjqTuYA==
   dependencies:
     ajv "^8.0.0"
     chalk "^4.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -11224,10 +11224,10 @@ react-native-macos@^0.66.0-0:
     whatwg-fetch "^3.0.0"
     ws "^6.1.4"
 
-react-native-test-app@^1.3.2:
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/react-native-test-app/-/react-native-test-app-1.3.2.tgz#9b01389712aff0b0568a0cae6beaeb5323052351"
-  integrity sha512-bRfe3vzH2LilfPgpDC1BZy6GRUWHfJOjRlDYu/B3J1acUCjxxnBle8f/anrNbu4TRL2au7/5zqIkUWXTjqTuYA==
+react-native-test-app@^1.3.4:
+  version "1.3.4"
+  resolved "https://registry.yarnpkg.com/react-native-test-app/-/react-native-test-app-1.3.4.tgz#d828620e93a8400c4502d1c15f7282f8922c3e47"
+  integrity sha512-+tdvSAXyKnpzq1EnILwMFS8AIETDW/Sahc+gaN4D9kQ0vB1C/OC0sC/ily5GMi1PokQI41xNktqOvq/V+Q4leA==
   dependencies:
     ajv "^8.0.0"
     chalk "^4.1.0"


### PR DESCRIPTION
## Summary

Consumers are getting "Cannot find module 'react-native-test-app'" when starting Metro dev server.

## Test Plan

n/a