### PR TITLE
fix: `multiGet` accepts read-only array

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -123,7 +123,7 @@ export type AsyncStorageStatic = {
    * See https://react-native-async-storage.github.io/async-storage/docs/api#multiget
    */
   multiGet: (
-    keys: string[],
+    keys: readonly string[],
     callback?: MultiGetCallback
   ) => Promise<readonly KeyValuePair[]>;
 


### PR DESCRIPTION
## Summary

Since `getAllKeys` returns `readonly string[]`, it make sense for other functions to accept keys in `readonly`.

Error screenshot:

![Screen Shot 2022-05-09 at 9 55 37 PM](https://user-images.githubusercontent.com/4337705/167386453-13e48366-c1af-405b-857b-d6711674face.png)


## Test Plan

TS compiles with no errors; tests are passing.