### PR TITLE
fix: invalid module name in augmentation

### DIFF
--- a/jest/async-storage-mock.d.ts
+++ b/jest/async-storage-mock.d.ts
@@ -1,0 +1,9 @@
+import type {
+  AsyncStorageHook,
+  AsyncStorageStatic,
+} from '../lib/typescript/types';
+
+export function useAsyncStorage(key: string): AsyncStorageHook;
+
+declare const AsyncStorage: AsyncStorageStatic;
+export default AsyncStorage;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,14 +1,5 @@
 import AsyncStorage from './AsyncStorage';
-import type { AsyncStorageHook, AsyncStorageStatic } from './types';
 
 export { useAsyncStorage } from './hooks';
-export type { AsyncStorageStatic } from './types';
 
 export default AsyncStorage;
-
-// @ts-ignore AsyncStorage mock module
-declare module '@react-native-async-storage/async-storage/jest/async-storage-mock' {
-  export function useAsyncStorage(key: string): AsyncStorageHook;
-  const AsyncStorageLib: AsyncStorageStatic;
-  export default AsyncStorageLib;
-}


### PR DESCRIPTION
This is an attempt to address #746. I'm having difficulties reproing this locally. I got a different error when importing the mocks directly which goes away with this.

Resolves #746.