### PR TITLE
fix: declare support for react-native 0.69

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "merge-options": "^3.0.4"
   },
   "peerDependencies": {
-    "react-native": "^0.0.0-0 || 0.60 - 0.68 || 1000.0.0"
+    "react-native": "^0.0.0-0 || 0.60 - 0.69 || 1000.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.12.0",


### PR DESCRIPTION
## Summary

AsyncStorage should still work fine with react-native 0.69

## Test Plan

n/a