### PR TITLE
fix: re-export AsyncStorageStatic type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,4 +2,6 @@ import AsyncStorage from './AsyncStorage';
 
 export { useAsyncStorage } from './hooks';
 
+export type { AsyncStorageStatic } from './types';
+
 export default AsyncStorage;


### PR DESCRIPTION
## Summary

Fix [regression](https://github.com/react-native-async-storage/async-storage/commit/db285138137b7d213598961b672be6ed8fade754) by re-introducing the export type statement in the index file.

## Test Plan

Relying on automation.
