### PR TITLE
ci: set up ccache for macOS builds

### DIFF
--- a/.ccache/ccache.conf
+++ b/.ccache/ccache.conf
@@ -1,0 +1,5 @@
+depend_mode = true
+direct_mode = true
+hard_link = true
+run_second_cpp = true
+sloppiness = file_stat_matches,include_file_ctime,include_file_mtime,ivfsoverlay,modules,system_headers,time_macros

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,17 +9,19 @@ jobs:
     name: 'macOS'
     runs-on: macos-latest
     steps:
-      - name: Set up Node.js
-        uses: actions/setup-node@v3.3.0
-        with:
-          node-version: 16
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Cache /.cache/yarn
+      - name: Cache /.ccache
         uses: actions/cache@v3
         with:
-          path: .cache/yarn
-          key: ${{ hashFiles('yarn.lock') }}
+          path: .ccache
+          key: ${{ runner.os }}-ccache-${{ hashFiles('yarn.lock') }}
+          restore-keys: ${{ runner.os }}-ccache-
+      - name: Set up Node.js
+        uses: actions/setup-node@v3.4.1
+        with:
+          node-version: 16
+          cache: 'yarn'
       - name: Install JS dependencies
         run: |
           yarn ci
@@ -41,17 +43,13 @@ jobs:
         uses: microsoft/setup-msbuild@v1.1
       - name: Setup VSTest.console.exe
         uses: darenm/Setup-VSTest@v1
-      - name: Set up Node.js
-        uses: actions/setup-node@v3.3.0
-        with:
-          node-version: 16
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Cache /.cache/yarn
-        uses: actions/cache@v3
+      - name: Set up Node.js
+        uses: actions/setup-node@v3.4.1
         with:
-          path: .cache/yarn
-          key: ${{ hashFiles('yarn.lock') }}
+          node-version: 16
+          cache: 'yarn'
       - name: Install JS dependencies
         run: |
           yarn ci

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "url": "https://github.com/react-native-async-storage/async-storage.git"
   },
   "scripts": {
-    "ci": "yarn --pure-lockfile --non-interactive --cache-folder .cache/yarn",
+    "ci": "yarn --pure-lockfile --non-interactive",
     "format": "concurrently yarn:format:*",
     "format:c": "clang-format -i $(git ls-files '*.cpp' '*.h' '*.m' '*.mm')",
     "format:js": "prettier --write $(git ls-files '*.js' '*.json' '*.md' '*.ts' '*.tsx' '*.yml')",


### PR DESCRIPTION
## Summary

Set up ccache for macOS builds.

## Test Plan

CI should pass. First builds should take as much time as it does today, but subsequent ones should be significantly faster.

| Before | After |
| - | - |
| [24m 32s](https://github.com/react-native-async-storage/async-storage/runs/8203935502?check_suite_focus=true) | [13m 31s](https://github.com/react-native-async-storage/async-storage/runs/8204398679?check_suite_focus=true) |