### PR TITLE
add name to tuple

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -10,7 +10,7 @@ export type CallbackWithResult<T> = (
   result?: T | null
 ) => void;
 
-export type KeyValuePair = [string, string | null];
+export type KeyValuePair = [path: string, string | null];
 
 export type MultiCallback = (errors?: readonly (Error | null)[] | null) => void;
 


### PR DESCRIPTION
## Summary

typescript supports named tuples
adding a bit more clarity to the return type of `multiGet`
havent checked that it works, more of a suggestion