### PR TITLE
ci: bump GitHub actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
           key: ${{ runner.os }}-ccache-${{ hashFiles('yarn.lock') }}
           restore-keys: ${{ runner.os }}-ccache-
       - name: Set up Node.js
-        uses: actions/setup-node@v3.4.1
+        uses: actions/setup-node@v3.5.1
         with:
           node-version: 16
           cache: 'yarn'
@@ -42,11 +42,11 @@ jobs:
       - name: Set up MSBuild
         uses: microsoft/setup-msbuild@v1.1
       - name: Setup VSTest.console.exe
-        uses: darenm/Setup-VSTest@v1
+        uses: darenm/Setup-VSTest@v1.2
       - name: Checkout
         uses: actions/checkout@v3
       - name: Set up Node.js
-        uses: actions/setup-node@v3.4.1
+        uses: actions/setup-node@v3.5.1
         with:
           node-version: 16
           cache: 'yarn'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -9,7 +9,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: actions/stale@v4
+      - uses: actions/stale@v7
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           stale-issue-message: 'This issue has been marked as stale due to inactivity. Please respond or otherwise resolve the issue within 7 days or it will be closed.'

--- a/.github/workflows/website-deployment.yml
+++ b/.github/workflows/website-deployment.yml
@@ -12,9 +12,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Cache/restore dependencies
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         id: cache
         with:
           path: ./website/node_modules


### PR DESCRIPTION
## Summary

We're seeing deprecation warnings on CI such as here: https://github.com/react-native-async-storage/async-storage/actions/runs/3864459872

Bumping all the actions to their latest versions to hopefully get rid of them.

## Test Plan

n/a