### PR TITLE
docs: document workaround for `inlineRequires` issues

### DIFF
--- a/website/docs/help/Troubleshooting.md
+++ b/website/docs/help/Troubleshooting.md
@@ -4,6 +4,52 @@ title: Troubleshooting
 sidebar_label: Troubleshooting
 ---
 
+## Async await doesn't resolve
+
+If you're having issues with `getItem()` and friends not resolving, check if
+`inlineRequires` is enabled in `metro.config.js`:
+
+```js
+module.exports = {
+  transformer: {
+    getTransformOptions: async () => ({
+      transform: {
+        experimentalImportSupport: false,
+        inlineRequires: true,
+      },
+    }),
+  },
+};
+```
+
+If disabling it resolves the issue, it's likely that you hit a circular import
+chain. You can try excluding `@react-native-async-storage/async-storage` from
+being inlined:
+
+```diff
+ module.exports = {
+   transformer: {
+     getTransformOptions: async () => ({
+       transform: {
+         experimentalImportSupport: false,
+         inlineRequires: true,
++        nonInlinedRequires: [
++          "@react-native-async-storage/async-storage",
++          'React',
++          'react',
++          'react-native',
++        ],
+       },
+     }),
+   },
+ };
+```
+
+If this doesn't resolve the issue, you need to figure out what is causing the
+cyclic chain. There are tools, such as
+[@rnx-kit/metro-plugin-cyclic-dependencies-detector](https://github.com/microsoft/rnx-kit/tree/main/packages/metro-plugin-cyclic-dependencies-detector#rnx-kitmetro-plugin-cyclic-dependencies-detector),
+that can help you debug this.
+
 ## [iOS] CocoaPods issues
 
 1. Delete the `node_modules` folder(s) from your project
@@ -54,7 +100,7 @@ info 1 error generated.
 
 ## [@RNC/AsyncStorage]: NativeModule: AsyncStorage is null
 
-#### iOS
+### iOS
 
 This error means that AsyncStorage was unable to find its native module. This
 occurs because AsyncStorage was not linked into the final app bundle.


### PR DESCRIPTION
## Summary

Document potential workaround/fix for `inlineRequires` issues. I haven't reproduced this myself, but from the numerous reports (both here and upstream), it sounds like we are hitting cyclic imports.

- https://github.com/react-native-async-storage/async-storage/issues/271
- https://github.com/react-native-async-storage/async-storage/issues/604
- https://github.com/react-native-async-storage/async-storage/issues/634
- https://github.com/react-native-async-storage/async-storage/issues/685
- https://github.com/react-native-async-storage/async-storage/issues/694
- https://github.com/react-native-async-storage/async-storage/issues/814

## Test Plan

n/a