### PR TITLE
Add info on where data is stored

### DIFF
--- a/website/docs/advanced/Where-data-stored.md
+++ b/website/docs/advanced/Where-data-stored.md
@@ -4,8 +4,8 @@ title: Where your data is stored
 sidebar_label: Where data is stored
 ---
 
-* <b>Android</b> - SQLite
-* <b>iOS</b> - small values (not exceeding 1024 characters) are serialized and stored in a common `manifest.json` file, while larger values are stored in individual, dedicated files (named as MD5 hashed `key`)
-* <b>Web</b> - window.localStorage
+* **Android** - SQLite
+* **iOS** - small values (not exceeding 1024 characters) are serialized and stored in a common `manifest.json` file, while larger values are stored in individual, dedicated files (named as MD5 hashed `key`)
 * **macOS** - Same as iOS
-* <b>Windows</b> - SQLite
+* **Web** - window.localStorage
+* **Windows** - SQLite

--- a/website/docs/advanced/Where-data-stored.md
+++ b/website/docs/advanced/Where-data-stored.md
@@ -7,5 +7,5 @@ sidebar_label: Where data is stored
 * <b>Android</b> - SQLite
 * <b>iOS</b> - small values (not exceeding 1024 characters) are serialized and stored in a common `manifest.json` file, while larger values are stored in individual, dedicated files (named as MD5 hashed `key`)
 * <b>Web</b> - window.localStorage
-* <b>MacOS</b> - Same as iOS
+* **macOS** - Same as iOS
 * <b>Windows</b> - SQLite

--- a/website/docs/advanced/Where-data-stored.md
+++ b/website/docs/advanced/Where-data-stored.md
@@ -1,0 +1,11 @@
+---
+id: where_data_stored
+title: Where your data is stored
+sidebar_label: Where data is stored
+---
+
+* <b>Android</b> - SQLite
+* <b>iOS</b> - small values (not exceeding 1024 characters) are serialized and stored in a common `manifest.json` file, while larger values are stored in individual, dedicated files (named as MD5 hashed `key`)
+* <b>Web</b> - window.localStorage
+* <b>MacOS</b> - Same as iOS
+* <b>Windows</b> - SQLite

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -1,7 +1,7 @@
 module.exports = {
   docs: {
     'Getting started': ['install', 'usage', 'api', 'limits'],
-    Advanced: ['advanced/next', 'advanced/jest', 'advanced/brownfield', 'advanced/backup', 'advanced/executor', 'advanced/db_size'],
+    Advanced: ['advanced/next', 'advanced/jest', 'advanced/brownfield', 'advanced/backup', 'advanced/executor', 'advanced/db_size','advanced/where_data_stored'],
     Debugging: ['debugging/communityPackages'],
     Help: ['help/troubleshooting'],
   },


### PR DESCRIPTION
## Summary

This is a docs change and relates to issue #905  - adding information on where data is stored.

I placed it under the advanced category in the sidebar. Let me know if you prefer it somewhere else. 

![CleanShot 2023-02-07 at 10 49 59](https://user-images.githubusercontent.com/7283908/217224725-d2bb5bb4-6105-450b-a538-428105c70a37.png)

## Test Plan

It is a docs change so likely just need to review that the docs run as they should. Let me know if you want me to do any other testing.

Thanks!!