### PR TITLE
ci: move JS jobs from CircleCI to GH

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,22 +111,6 @@ jobs:
           root: .
           paths: .
 
-  "Test: lint":
-    <<: *js_defaults
-    steps:
-      - *addWorkspace
-      - run:
-          name: Lint check
-          command: yarn test:lint
-
-  "Test: TypeScript":
-    <<: *js_defaults
-    steps:
-      - *addWorkspace
-      - run:
-          name: TypeScript check
-          command: yarn test:ts
-
   "Test: Android unit":
     <<: *android_defaults
     steps:
@@ -266,23 +250,14 @@ workflows:
   "Testing":
     jobs:
       - "Setup environment"
-      - "Test: lint":
-          requires:
-            - "Setup environment"
-      - "Test: TypeScript":
-          requires:
-            - "Setup environment"
       - "Test: Android unit":
           requires:
             - "Setup environment"
       - "Test: iOS e2e":
           requires:
-            - "Test: lint"
-            - "Test: TypeScript"
+            - "Setup environment"
       - "Test: Android e2e":
           requires:
-            - "Test: lint"
-            - "Test: TypeScript"
             - "Test: Android unit"
           filters:
             branches:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,26 @@ on:
       - master
   pull_request:
 jobs:
+  review:
+    name: 'Review'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Set up Node.js
+        uses: actions/setup-node@v3.6.0
+        with:
+          node-version: 16
+          cache: 'yarn'
+      - name: Install JS dependencies
+        run: |
+          yarn
+      - name: Lint
+        run: |
+          yarn test:lint
+      - name: TypeScript
+        run: |
+          yarn test:ts
   macos:
     name: 'macOS'
     runs-on: macos-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
           key: ${{ runner.os }}-ccache-${{ hashFiles('yarn.lock') }}
           restore-keys: ${{ runner.os }}-ccache-
       - name: Set up Node.js
-        uses: actions/setup-node@v3.5.1
+        uses: actions/setup-node@v3.6.0
         with:
           node-version: 16
           cache: 'yarn'
@@ -60,13 +60,13 @@ jobs:
     runs-on: windows-2019
     steps:
       - name: Set up MSBuild
-        uses: microsoft/setup-msbuild@v1.1
+        uses: microsoft/setup-msbuild@v1.3
       - name: Setup VSTest.console.exe
         uses: darenm/Setup-VSTest@v1.2
       - name: Checkout
         uses: actions/checkout@v3
       - name: Set up Node.js
-        uses: actions/setup-node@v3.5.1
+        uses: actions/setup-node@v3.6.0
         with:
           node-version: 16
           cache: 'yarn'

--- a/yarn.lock
+++ b/yarn.lock
@@ -12979,8 +12979,8 @@ __metadata:
   linkType: hard
 
 "react-native-windows@npm:^0.68.0":
-  version: 0.68.26
-  resolution: "react-native-windows@npm:0.68.26"
+  version: 0.68.27
+  resolution: "react-native-windows@npm:0.68.27"
   dependencies:
     "@babel/runtime": ^7.0.0
     "@jest/create-cache-key-function": ^27.0.1
@@ -13021,7 +13021,7 @@ __metadata:
   peerDependencies:
     react: 17.0.2
     react-native: ^0.68.0
-  checksum: ea41e89da22d52acb2338853e7d320512f381f112f807d5cde50d7f9ffbbe99c5d846867ea9f915e2f3401debc16f23ab998520fe9652681503d01f7f2e18ffc
+  checksum: 93b4ec1af7beb71be891e3830fb0b9f06ddbe6b6754fe65e53a23c3680ea174d6d2406363477e193cd010786cdc793a1e0ad2d9f63c589ac7efd6cde97d52426
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Move JS related jobs from CircleCI to GitHub Actions.

## Test Plan

CI should pass.