### PR TITLE
Allow consumption of RCTAsyncStorage as TurboModule

### DIFF
--- a/src/RCTAsyncStorage.ts
+++ b/src/RCTAsyncStorage.ts
@@ -2,15 +2,18 @@
 import { NativeModules, TurboModuleRegistry } from 'react-native';
 import { shouldFallbackToLegacyNativeModule } from './shouldFallbackToLegacyNativeModule';
 
-let RCTAsyncStorage =
-  NativeModules['PlatformLocalStorage'] || // Support for external modules, like react-native-windows
-  NativeModules['RNC_AsyncSQLiteDBStorage'] ||
-  NativeModules['RNCAsyncStorage'];
+// TurboModuleRegistry falls back to NativeModules so we don't have to try go
+// assign NativeModules' counterparts if TurboModuleRegistry would resolve
+// with undefined.
+let RCTAsyncStorage = TurboModuleRegistry
+  ? TurboModuleRegistry.get('PlatformLocalStorage') || // Support for external modules, like react-native-windows
+    TurboModuleRegistry.get('RNC_AsyncSQLiteDBStorage') ||
+    TurboModuleRegistry.get('RNCAsyncStorage');
+  : NativeModules['PlatformLocalStorage'] || // Support for external modules, like react-native-windows
+    NativeModules['RNC_AsyncSQLiteDBStorage'] ||
+    NativeModules['RNCAsyncStorage'];
 
 if (!RCTAsyncStorage && shouldFallbackToLegacyNativeModule()) {
-  // TurboModuleRegistry falls back to NativeModules so we don't have to try go
-  // assign NativeModules' counterparts if TurboModuleRegistry would resolve
-  // with undefined.
   if (TurboModuleRegistry) {
     RCTAsyncStorage =
       TurboModuleRegistry.get('AsyncSQLiteDBStorage') ||


### PR DESCRIPTION
## Summary

<!--
  Thank you for submitting a PR!

  Help us understand more of your work - you can explain what you did, post a
  link to an issue, screenshots etc. Anything helps!
-->

In react-native-windows, attributed C++ modules can be consumed as either a legacy native module or TurboModule. This change enables registration of RNCAsyncStorage as a TurboModule.

## Test Plan

<!--
    Help us test your work (**REQUIRED**).

    If you changed the code, please provide us with instructions of how we can
    try it out ourselves, so we can confirm it's working. You can also post
    screenshots/gifts.
-->

Tested this out in a react-native-windows C++ app, where instead of using the [ReactPackageProvider](https://github.com/react-native-async-storage/async-storage/blob/master/windows/code/ReactPackageProvider.idl), I register [RNCAsyncStorage.h](https://github.com/react-native-async-storage/async-storage/blob/master/windows/code/RNCAsyncStorage.h) directly as a TurboModule.