### PR TITLE
ci: Separate release action from PR action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ jobs:
   review:
     name: Review
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        test-name: [lint, ts]
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -17,14 +20,9 @@ jobs:
           node-version: 16
           cache: yarn
       - name: Install JS dependencies
-        run: |
-          yarn
-      - name: Lint
-        run: |
-          yarn test:lint
-      - name: TypeScript
-        run: |
-          yarn test:ts
+        run: yarn --frozen-lockfile
+      - name: Run test ${{ matrix.test-name }}
+        run: yarn test:${{ matrix.test-name }}
   android:
     name: Android
     runs-on: ubuntu-22.04
@@ -142,6 +140,7 @@ jobs:
   release:
     name: Release
     needs: [review, android, ios, macos, windows]
+    if: github.event_name == 'push'
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
           node-version: 16
           cache: yarn
       - name: Install JS dependencies
-        run: yarn --frozen-lockfile
+        run: yarn
       - name: Run test ${{ matrix.test-name }}
         run: yarn test:${{ matrix.test-name }}
   android:


### PR DESCRIPTION
## Summary

~Removing release~ Making sure release action is run only on push actions, so that it would not fail, due to lack of access to secrets.

Also, running TS/Lint in a matrix as a bonus
