### PR TITLE
Fix macOS example block in react-native-config

### DIFF
--- a/react-native.config.js
+++ b/react-native.config.js
@@ -10,7 +10,7 @@ const project = (() => {
         sourceDir: path.join('example', 'ios'),
       },
       macos: {
-        sourceDir: path.join('example', 'maacos'),
+        sourceDir: path.join('example', 'macos'),
       },
       windows: {
         sourceDir: path.join('example', 'windows'),


### PR DESCRIPTION
## Summary

#910 added TM Support! In that PR we added support for macOS in `react-native.config.js`
Fix a typo in the `sourceDir` config. 
This was tested on macOS but did't cause issues, assuming react-native-test-app takes care of setting up this example dir?

## Test Plan

macOS builds