### PR TITLE
Update build.gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -86,6 +86,7 @@ if (isNewArchitectureEnabled()) {
 }
 
 android {
+    namespace "com.reactnativecommunity.asyncstorage"
     compileSdkVersion safeExtGet('compileSdkVersion', 32)
     // Used to override the NDK path/version by allowing users to customize
     // the NDK path/version from their root project (e.g. for M1 support)


### PR DESCRIPTION
Fixed react native >= 0.72 `Could not create an instance of type com.android.build.api.variant.impl.LibraryVariantBuilderImpl. Namespace not specified. Please specify a namespace in the module's build.gradle file like so`

## Summary

<!--
  Thank you for submitting a PR!

  Help us understand more of your work - you can explain what you did, post a
  link to an issue, screenshots etc. Anything helps!
-->

## Test Plan

<!--
    Help us test your work (**REQUIRED**).

    If you changed the code, please provide us with instructions of how we can
    try it out ourselves, so we can confirm it's working. You can also post
    screenshots/gifts.
-->
