### PR TITLE
chore: move to `main` trunk

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
 jobs:
   review:

--- a/.github/workflows/website-deployment.yml
+++ b/.github/workflows/website-deployment.yml
@@ -2,7 +2,7 @@ name: Website Deployment
 on:
   push:
     branches:
-      - master
+      - main
     paths:
       - 'website/**'
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,7 @@ When you're sending a pull request:
 
 ## Commits and versioning
 
-All PRs are squashed into `master` branch and wrapped up in a single commit,
+All PRs are squashed into `main` branch and wrapped up in a single commit,
 following
 [conventional commit message](https://www.conventionalcommits.org/en/v1.0.0-beta.3).
 Combined with [semantic versioning](https://semver.org/), this allows us to have
@@ -66,7 +66,7 @@ Most notably prefixes you'll see:
 ## Release process
 
 We use [Semantic Release](http://semantic-release.org) to automatically release
-new versions of the library when changes are merged into `master` branch, which
+new versions of the library when changes are merged into `main` branch, which
 we plan to keep stable. Bug fixes take priority in the release order.
 
 ## Reporting issues

--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
   },
   "release": {
     "branches": [
-      "master"
+      "main"
     ],
     "plugins": [
       "@semantic-release/commit-analyzer",

--- a/website/docs/advanced/Jest-integration.md
+++ b/website/docs/advanced/Jest-integration.md
@@ -74,5 +74,5 @@ export default AsyncStorageMock;
 ```
 
 You can
-[check its implementation](https://github.com/react-native-async-storage/async-storage/blob/master/jest/async-storage-mock.js)
+[check its implementation](https://github.com/react-native-async-storage/async-storage/blob/main/jest/async-storage-mock.js)
 to get more insight into methods signatures.

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -77,7 +77,7 @@ module.exports = {
         docs: {
           sidebarPath: require.resolve('./sidebars.js'),
           editUrl:
-            'https://github.com/react-native-async-storage/async-storage/edit/master/website/',
+            'https://github.com/react-native-async-storage/async-storage/edit/main/website/',
         },
         theme: {
           customCss: require.resolve('./src/css/custom.css'),


### PR DESCRIPTION
## Summary

Ditching `master` in favor of `main`
