### PR TITLE
Fix `pod install` on RN 0.70.x + New Arch

### DIFF
--- a/packages/default-storage-backend/RNCAsyncStorage.podspec
+++ b/packages/default-storage-backend/RNCAsyncStorage.podspec
@@ -24,9 +24,18 @@ Pod::Spec.new do |s|
       'CLANG_CXX_LANGUAGE_STANDARD' => 'c++17',
     }
     s.platforms       = { ios: '13.4', tvos: '11.0', :osx => "10.15" }
-    s.compiler_flags  = folly_compiler_flags + ' -DRCT_NEW_ARCH_ENABLED'
+    s.compiler_flags  = folly_compiler_flags + ' -DRCT_NEW_ARCH_ENABLED=1'
 
-    install_modules_dependencies(s)
+    if respond_to?(:install_modules_dependencies, true)
+      install_modules_dependencies(s)
+    else
+      s.dependency "React-Core"
+      s.dependency "React-Codegen"
+      s.dependency "RCT-Folly"
+      s.dependency "RCTRequired"
+      s.dependency "RCTTypeSafety"
+      s.dependency "ReactCommon/turbomodule/core"
+    end
   else
     s.platforms = { :ios => "9.0", :tvos => "9.2", :osx => "10.14" }
 


### PR DESCRIPTION
## Summary

Issue: https://github.com/react-native-async-storage/async-storage/issues/997

## Test Plan

```shell
npx react-native@0.70.13 init Rn70New --version 0.70.13
cd Rn70New
yarn add "https://gitpkg.now.sh/retyui/async-storage/packages/default-storage-backend?fix-new-arch-pod-install"
# add "platform :ios, '13.4'" in  `ios/Podfile` 
RCT_NEW_ARCH_ENABLED=1 npx pod-install
```

<img width="1190" alt="Screenshot 2023-08-22 at 14 19 58" src="https://github.com/react-native-async-storage/async-storage/assets/4661784/5e862137-78cf-49be-add3-652d8250d59e">

