### PR TITLE
[tvOS] Apple TV warning should only happen once

### DIFF
--- a/packages/default-storage-backend/ios/RNCAsyncStorage.mm
+++ b/packages/default-storage-backend/ios/RNCAsyncStorage.mm
@@ -155,6 +155,10 @@ static NSString *RCTGetStorageDirectory()
     static NSString *storageDirectory = nil;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
+#if TARGET_OS_TV
+      RCTLogWarn(
+        @"Persistent storage is not supported on tvOS, your data may be removed at any point.");
+#endif
       storageDirectory = RCTCreateStorageDirectoryPath(RCTStorageDirectory);
     });
     return storageDirectory;
@@ -498,11 +502,6 @@ RCT_EXPORT_MODULE()
 - (NSDictionary *)_ensureSetup
 {
     RCTAssertThread(RCTGetMethodQueue(), @"Must be executed on storage thread");
-
-#if TARGET_OS_TV
-    RCTLogWarn(
-        @"Persistent storage is not supported on tvOS, your data may be removed at any point.");
-#endif
 
     NSError *error = nil;
     if (!RCTHasCreatedStorageDirectory) {


### PR DESCRIPTION
## Summary

It is not necessary for Apple TV to do a logbox warning about async storage every time the app is reloaded.

This change just places the warning in a `dispatch_once()` so that it occurs only when the app is started.

## Test Plan

Tested using the app at https://github.com/douglowder/IgniteTVTest, which has the patch provided in this PR.
