### PR TITLE
Set iOS target to 12.4 for new architecture

### DIFF
--- a/packages/default-storage-backend/RNCAsyncStorage.podspec
+++ b/packages/default-storage-backend/RNCAsyncStorage.podspec
@@ -23,7 +23,7 @@ Pod::Spec.new do |s|
       'HEADER_SEARCH_PATHS' => '"$(PODS_ROOT)/boost" "$(PODS_ROOT)/boost-for-react-native" "$(PODS_ROOT)/RCT-Folly"',
       'CLANG_CXX_LANGUAGE_STANDARD' => 'c++17',
     }
-    s.platforms       = { ios: '13.4', tvos: '11.0', :osx => "10.15" }
+    s.platforms       = { ios: '12.4', tvos: '11.0', :osx => "10.15" }
     s.compiler_flags  = folly_compiler_flags + ' -DRCT_NEW_ARCH_ENABLED=1'
 
     if respond_to?(:install_modules_dependencies, true)


### PR DESCRIPTION
## Summary

Hey, I assume this was a typo as react-native itself sets 12.4 as the minimum required version.
Without this change, you'll get a build error in the default react-native template and configuration.
