### PR TITLE
chore(android): Bump version for Next storage

### DIFF
--- a/packages/default-storage/android/build.gradle
+++ b/packages/default-storage/android/build.gradle
@@ -19,12 +19,10 @@ buildscript {
 
 
 apply plugin: 'com.android.library'
-apply from: "config.gradle"
+apply from: 'config.gradle'
 
 boolean isNewArchitectureEnabled = ext.AsyncStorageConfig.isNewArchitectureEnabled
 boolean useNextStorage = ext.AsyncStorageConfig.useNextStorage
-
-println("[AsyncStorage] Config: ${ext.AsyncStorageConfig}")
 
 if (useNextStorage) {
     apply plugin: 'com.google.devtools.ksp'
@@ -103,26 +101,20 @@ repositories {
 dependencies {
     if (useNextStorage) {
         def room_version = project.ext.AsyncStorageConfig.roomVersion
-        def coroutines_version = "1.7.3"
-        def junit_version = "4.13.2"
-        def robolectric_version = "4.11.1"
-        def truth_version = "1.1.3"
-        def androidxtest_version = "1.4.0"
-        def androidtest_junit_version = "1.1.3"
 
         implementation "androidx.room:room-runtime:$room_version"
         implementation "androidx.room:room-ktx:$room_version"
         ksp "androidx.room:room-compiler:$room_version"
 
-        implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutines_version"
+        implementation project.ext.AsyncStorageLibs.coroutines
 
-        testImplementation "junit:junit:$junit_version"
-        testImplementation "androidx.test:runner:$androidxtest_version"
-        testImplementation "androidx.test:rules:$androidxtest_version"
-        testImplementation "androidx.test.ext:junit:$androidtest_junit_version"
-        testImplementation "org.robolectric:robolectric:$robolectric_version"
-        testImplementation "com.google.truth:truth:$truth_version"
-        testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:$coroutines_version"
+        testImplementation project.ext.AsyncStorageLibs.testCoroutines
+        testImplementation project.ext.AsyncStorageLibs.testJunit
+        testImplementation project.ext.AsyncStorageLibs.testExtJunit
+        testImplementation project.ext.AsyncStorageLibs.testRunner
+        testImplementation project.ext.AsyncStorageLibs.testRules
+        testImplementation project.ext.AsyncStorageLibs.testRobolectric
+        testImplementation project.ext.AsyncStorageLibs.testTruth
     }
 
     implementation 'com.facebook.react:react-native:+' // from node_modules

--- a/packages/default-storage/android/build.gradle
+++ b/packages/default-storage/android/build.gradle
@@ -105,7 +105,7 @@ dependencies {
         def room_version = project.ext.AsyncStorageConfig.roomVersion
         def coroutines_version = "1.7.3"
         def junit_version = "4.13.2"
-        def robolectric_version = "4.7.3"
+        def robolectric_version = "4.11.1"
         def truth_version = "1.1.3"
         def androidxtest_version = "1.4.0"
         def androidtest_junit_version = "1.1.3"

--- a/packages/default-storage/android/build.gradle
+++ b/packages/default-storage/android/build.gradle
@@ -1,92 +1,38 @@
-import java.nio.file.Paths
-
-def resolveModulePath(packageName) {
-    def basePath = rootDir.toPath().normalize()
-
-    // Node's module resolution algorithm searches up to the root directory,
-    // after which the base path will be null
-    while (basePath) {
-        def candidatePath = Paths.get(basePath.toString(), 'node_modules', packageName)
-        if (candidatePath.toFile().exists()) {
-            return candidatePath.toString()
-        }
-
-        basePath = basePath.getParent()
-    }
-
-    return null
-}
-
-def safeExtGet(prop, fallback) {
-    rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
-}
-
-def getFlagOrDefault(flagName, defaultValue) {
-    rootProject.hasProperty(flagName) ? rootProject.properties[flagName] == "true" : defaultValue
-}
-
-def getVersionOrDefault(String flagName, String defaultVersion) {
-    rootProject.hasProperty(flagName) ? rootProject.properties[flagName] : defaultVersion
-}
-
-def isNewArchitectureEnabled() {
-    // To opt-in for the New Architecture, you can either:
-    // - Set `newArchEnabled` to true inside the `gradle.properties` file
-    // - Invoke gradle with `-newArchEnabled=true`
-    // - Set an environment variable `ORG_GRADLE_PROJECT_newArchEnabled=true`
-    return project.hasProperty("newArchEnabled") && project.newArchEnabled == "true"
-}
-
 configurations {
     compileClasspath
 }
 
 buildscript {
-    // kotlin version is dictated by rootProject extension or property in gradle.properties
-    ext.asyncStorageKtVersion = rootProject.ext.has('kotlinVersion')
-            ? rootProject.ext['kotlinVersion']
-            : rootProject.hasProperty('AsyncStorage_kotlinVersion')
-            ? rootProject.properties['AsyncStorage_kotlinVersion']
-            : '1.9.20'
-
-    def kspVersion = rootProject.hasProperty("AsyncStorage_next_kspVersion")
-            ? rootProject.properties["AsyncStorage_next_kspVersion"]
-            : '1.9.20-1.0.14'
+    apply from: "config.gradle"
+    def kotlinVersion = ext.AsyncStorageConfig.kotlinVersion
+    def kspVersion = ext.AsyncStorageConfig.kspVersion
 
     repositories {
         mavenCentral()
         google()
     }
     dependencies {
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$asyncStorageKtVersion"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
         classpath "com.google.devtools.ksp:symbol-processing-gradle-plugin:$kspVersion"
     }
 }
 
-// AsyncStorage has default size of 6MB.
-// This is a sane limit to protect the user from the app storing too much data in the database.
-// This also protects the database from filling up the disk cache and becoming malformed.
-// If you really need bigger size, please keep in mind the potential consequences.
-long dbSizeInMB = 6L
-def newDbSize = rootProject.properties['AsyncStorage_db_size_in_MB']
-if (newDbSize != null && newDbSize.isLong()) {
-    dbSizeInMB = newDbSize.toLong()
-}
-
-// Instead of reusing AsyncTask thread pool, AsyncStorage can use its own executor
-def useDedicatedExecutor = getFlagOrDefault('AsyncStorage_dedicatedExecutor', false)
-
-// Use next storage implementation
-def useNextStorage = getFlagOrDefault("AsyncStorage_useNextStorage", false)
 
 apply plugin: 'com.android.library'
+apply from: "config.gradle"
+
+boolean isNewArchitectureEnabled = ext.AsyncStorageConfig.isNewArchitectureEnabled
+boolean useNextStorage = ext.AsyncStorageConfig.useNextStorage
+
+println("[AsyncStorage] Config: ${ext.AsyncStorageConfig}")
+
 if (useNextStorage) {
     apply plugin: 'com.google.devtools.ksp'
     apply plugin: 'kotlin-android'
     apply from: './testresults.gradle'
 }
 
-if (isNewArchitectureEnabled()) {
+if (isNewArchitectureEnabled) {
     apply plugin: "com.facebook.react"
 }
 
@@ -99,7 +45,7 @@ android {
         }
     }
 
-    compileSdkVersion safeExtGet('compileSdkVersion', 32)
+    compileSdkVersion project.ext.AsyncStorageConfig.compileSdkVersion
     // Used to override the NDK path/version by allowing users to customize
     // the NDK path/version from their root project (e.g. for M1 support)
     if (rootProject.hasProperty("ndkPath")) {
@@ -111,10 +57,10 @@ android {
 
 
     defaultConfig {
-        minSdkVersion safeExtGet('minSdkVersion', 23)
-        targetSdkVersion safeExtGet('targetSdkVersion', 32)
-        buildConfigField "Long", "AsyncStorage_db_size", "${dbSizeInMB}L"
-        buildConfigField "boolean", "AsyncStorage_useDedicatedExecutor", "${useDedicatedExecutor}"
+        minSdkVersion project.ext.AsyncStorageConfig.minSdkVersion
+        targetSdkVersion project.ext.AsyncStorageConfig.targetSdkVersion
+        buildConfigField "Long", "AsyncStorage_db_size", "${project.ext.AsyncStorageConfig.databaseSizeMB}L"
+        buildConfigField "boolean", "AsyncStorage_useDedicatedExecutor", "${project.ext.AsyncStorageConfig.useDedicatedExecutor}"
         buildConfigField "boolean", "AsyncStorage_useNextStorage", "${useNextStorage}"
     }
     lintOptions {
@@ -138,7 +84,7 @@ android {
                 srcDirs += 'src/javaPackage/java'
             }
 
-            if (!isNewArchitectureEnabled()) {
+            if (!isNewArchitectureEnabled) {
                 srcDirs += 'src/oldarch/java'
             }
         }
@@ -148,16 +94,15 @@ android {
 repositories {
     maven {
         // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
-        url "${resolveModulePath("react-native")}/android"
+        url "${project.ext.resolveModulePath("react-native")}/android"
     }
     google()
     mavenCentral()
 }
 
 dependencies {
-
     if (useNextStorage) {
-        def room_version = getVersionOrDefault('AsyncStorage_next_roomVersion', '2.4.3')
+        def room_version = project.ext.AsyncStorageConfig.roomVersion
         def coroutines_version = "1.7.3"
         def junit_version = "4.13.2"
         def robolectric_version = "4.7.3"

--- a/packages/default-storage/android/build.gradle
+++ b/packages/default-storage/android/build.gradle
@@ -47,7 +47,11 @@ buildscript {
             ? rootProject.ext['kotlinVersion']
             : rootProject.hasProperty('AsyncStorage_kotlinVersion')
             ? rootProject.properties['AsyncStorage_kotlinVersion']
-            : '1.8.10'
+            : '1.9.20'
+
+    def kspVersion = rootProject.hasProperty("AsyncStorage_next_kspVersion")
+            ? rootProject.properties["AsyncStorage_next_kspVersion"]
+            : '1.9.20-1.0.14'
 
     repositories {
         mavenCentral()
@@ -55,6 +59,7 @@ buildscript {
     }
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$asyncStorageKtVersion"
+        classpath "com.google.devtools.ksp:symbol-processing-gradle-plugin:$kspVersion"
     }
 }
 
@@ -76,8 +81,8 @@ def useNextStorage = getFlagOrDefault("AsyncStorage_useNextStorage", false)
 
 apply plugin: 'com.android.library'
 if (useNextStorage) {
+    apply plugin: 'com.google.devtools.ksp'
     apply plugin: 'kotlin-android'
-    apply plugin: 'kotlin-kapt'
     apply from: './testresults.gradle'
 }
 
@@ -153,12 +158,7 @@ dependencies {
 
     if (useNextStorage) {
         def room_version = getVersionOrDefault('AsyncStorage_next_roomVersion', '2.4.3')
-        def coroutines_version = "1.6.4"
-        def coroutinesTest_version = "1.6.4"
-        // if we don't provide explicit dependency on reflection, kotlin plugin
-        // would add one automatically, probably a version that is not compatible with
-        // used kotlin
-        def kotlinReflect_version = project.ext.asyncStorageKtVersion
+        def coroutines_version = "1.7.3"
         def junit_version = "4.13.2"
         def robolectric_version = "4.7.3"
         def truth_version = "1.1.3"
@@ -167,10 +167,9 @@ dependencies {
 
         implementation "androidx.room:room-runtime:$room_version"
         implementation "androidx.room:room-ktx:$room_version"
-        implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlinReflect_version"
+        ksp "androidx.room:room-compiler:$room_version"
 
         implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutines_version"
-        kapt "androidx.room:room-compiler:$room_version"
 
         testImplementation "junit:junit:$junit_version"
         testImplementation "androidx.test:runner:$androidxtest_version"
@@ -178,7 +177,7 @@ dependencies {
         testImplementation "androidx.test.ext:junit:$androidtest_junit_version"
         testImplementation "org.robolectric:robolectric:$robolectric_version"
         testImplementation "com.google.truth:truth:$truth_version"
-        testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:$coroutinesTest_version"
+        testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:$coroutines_version"
     }
 
     implementation 'com.facebook.react:react-native:+' // from node_modules

--- a/packages/default-storage/android/build.gradle
+++ b/packages/default-storage/android/build.gradle
@@ -24,6 +24,8 @@ apply from: 'config.gradle'
 boolean isNewArchitectureEnabled = ext.AsyncStorageConfig.isNewArchitectureEnabled
 boolean useNextStorage = ext.AsyncStorageConfig.useNextStorage
 
+logger.info("[AsyncStorage] Config used: {}", ext.AsyncStorageConfig)
+
 if (useNextStorage) {
     apply plugin: 'com.google.devtools.ksp'
     apply plugin: 'kotlin-android'

--- a/packages/default-storage/android/config.gradle
+++ b/packages/default-storage/android/config.gradle
@@ -1,0 +1,106 @@
+import java.nio.file.Paths
+
+def DEFAULT_KOTLIN_VERSION = "1.9.20"
+def DEFAULT_ROOM_VERSION = "2.4.3"
+
+project.ext.AsyncStorageConfig = [
+        kotlinVersion           : getKotlinVersion(),
+        kspVersion              : getKspVersion(kotlinVersion),
+        roomVersion             : getPropertyOfDefault('AsyncStorage_next_roomVersion', DEFAULT_ROOM_VERSION),
+        minSdkVersion           : safeExtGet('minSdkVersion', 23),
+        targetSdkVersion        : safeExtGet('targetSdkVersion', 32),
+        compileSdkVersion       : safeExtGet('compileSdkVersion', 32),
+        useNextStorage          : getFlagOrDefault("AsyncStorage_useNextStorage", false),
+        databaseSizeMB          : getDatabaseSize(),
+        isNewArchitectureEnabled: isNewArchitectureEnabled(),
+        useDedicatedExecutor    : getFlagOrDefault('AsyncStorage_dedicatedExecutor', false),
+]
+
+
+def getKotlinVersion() {
+    return rootProject.ext.has('kotlinVersion')
+            ? rootProject.ext['kotlinVersion']
+            : rootProject.hasProperty('AsyncStorage_kotlinVersion')
+            ? rootProject.properties['AsyncStorage_kotlinVersion']
+            : DEFAULT_KOTLIN_VERSION
+}
+
+def isNewArchitectureEnabled() {
+    // To opt-in for the New Architecture, you can either:
+    // - Set `newArchEnabled` to true inside the `gradle.properties` file
+    // - Invoke gradle with `-newArchEnabled=true`
+    // - Set an environment variable `ORG_GRADLE_PROJECT_newArchEnabled=true`
+    return project.hasProperty("newArchEnabled") && project.newArchEnabled == "true"
+}
+
+String getKspVersion(String kotlinVersion) {
+
+    String overriddenKspVersion = getPropertyOfDefault("AsyncStorage_next_kspVersion", null)
+    if (overriddenKspVersion != null) {
+        return overriddenKspVersion
+    }
+    // https://github.com/google/ksp/releases
+    return [
+            "1.9.20-1.0.14",
+            "1.9.10-1.0.13",
+            "1.9.0-1.0.13",
+            "1.8.22-1.0.11",
+            "1.8.21-1.0.11",
+            "1.8.20-1.0.11",
+            "1.8.10-1.0.9",
+            "1.8.0-1.0.9",
+            "1.7.22-1.0.8",
+            "1.7.21-1.0.8",
+            "1.7.20-1.0.8",
+            "1.7.10-1.0.6",
+            "1.7.0-1.0.6",
+            "1.6.21-1.0.6",
+            "1.6.20-1.0.5",
+            "1.6.10-1.0.4",
+            "1.6.0-1.0.2",
+            "1.5.31-1.0.1",
+            "1.5.30-1.0.0",
+    ].find { it.startsWith(kotlinVersion) }
+}
+
+// AsyncStorage has default size of 6MB.
+// This is a sane limit to protect the user from the app storing too much data in the database.
+// This also protects the database from filling up the disk cache and becoming malformed.
+// If you really need bigger size, please keep in mind the potential consequences.
+long getDatabaseSize() {
+    long dbSizeInMB = 6L
+    def newDbSize = getPropertyOfDefault('AsyncStorage_db_size_in_MB', null)
+    if (newDbSize != null && newDbSize.isLong()) {
+        dbSizeInMB = newDbSize.toLong()
+    }
+    return dbSizeInMB
+}
+
+def safeExtGet(prop, fallback) {
+    rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
+def getFlagOrDefault(flagName, defaultValue) {
+    rootProject.hasProperty(flagName) ? rootProject.properties[flagName] == "true" : defaultValue
+}
+
+def getPropertyOfDefault(String flagName, String defaultVersion) {
+    rootProject.hasProperty(flagName) ? rootProject.properties[flagName] : defaultVersion
+}
+
+ext.resolveModulePath = { packageName ->
+    def basePath = rootDir.toPath().normalize()
+
+    // Node's module resolution algorithm searches up to the root directory,
+    // after which the base path will be null
+    while (basePath) {
+        def candidatePath = Paths.get(basePath.toString(), 'node_modules', packageName)
+        if (candidatePath.toFile().exists()) {
+            return candidatePath.toString()
+        }
+
+        basePath = basePath.getParent()
+    }
+
+    return null
+}

--- a/packages/default-storage/android/config.gradle
+++ b/packages/default-storage/android/config.gradle
@@ -51,7 +51,7 @@ String getKspVersion(String kotlinVersion) {
         return overriddenKspVersion
     }
     // https://github.com/google/ksp/releases
-    return [
+    def kspVersions = [
             "1.9.20-1.0.14",
             "1.9.10-1.0.13",
             "1.9.0-1.0.13",
@@ -71,7 +71,9 @@ String getKspVersion(String kotlinVersion) {
             "1.6.0-1.0.2",
             "1.5.31-1.0.1",
             "1.5.30-1.0.0",
-    ].find { it.startsWith(kotlinVersion) }
+    ]
+
+    return kspVersions.find { it.startsWith(kotlinVersion) } ?: kspVersions.first()
 }
 
 // AsyncStorage has default size of 6MB.

--- a/packages/default-storage/android/config.gradle
+++ b/packages/default-storage/android/config.gradle
@@ -4,7 +4,7 @@ def DEFAULT_KOTLIN_VERSION = "1.9.20"
 def DEFAULT_ROOM_VERSION = "2.4.3"
 
 project.ext.AsyncStorageConfig = [
-        kotlinVersion           : getKotlinVersion(),
+        kotlinVersion           : getKotlinVersion(DEFAULT_KOTLIN_VERSION),
         kspVersion              : getKspVersion(kotlinVersion),
         roomVersion             : getPropertyOfDefault('AsyncStorage_next_roomVersion', DEFAULT_ROOM_VERSION),
         minSdkVersion           : safeExtGet('minSdkVersion', 23),
@@ -16,13 +16,24 @@ project.ext.AsyncStorageConfig = [
         useDedicatedExecutor    : getFlagOrDefault('AsyncStorage_dedicatedExecutor', false),
 ]
 
+project.ext.AsyncStorageLibs = [
+        coroutines     : "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3",
+        testCoroutines : "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.3",
+        testJunit      : "junit:junit:4.13.2",
+        testRunner     : "androidx.test:runner:1.4.0",
+        testRules      : "androidx.test:rules:1.4.0",
+        testExtJunit   : "androidx.test.ext:junit:1.1.3",
+        testRobolectric: "org.robolectric:robolectric:4.11.1",
+        testTruth      : "com.google.truth:truth:1.1.3",
+]
 
-def getKotlinVersion() {
+
+def getKotlinVersion(String defaultVersion) {
     return rootProject.ext.has('kotlinVersion')
             ? rootProject.ext['kotlinVersion']
             : rootProject.hasProperty('AsyncStorage_kotlinVersion')
             ? rootProject.properties['AsyncStorage_kotlinVersion']
-            : DEFAULT_KOTLIN_VERSION
+            : defaultVersion
 }
 
 def isNewArchitectureEnabled() {

--- a/packages/default-storage/example/android/gradle.properties
+++ b/packages/default-storage/example/android/gradle.properties
@@ -42,7 +42,7 @@ newArchEnabled=true
 #ANDROID_NDK_VERSION=21.4.7075529
 
 # Version of Kotlin to build against.
-KOTLIN_VERSION=1.8.10
+KOTLIN_VERSION=1.9.20
 
 # This is an example of how you can change default DB size (6MB) to 10MB
 #AsyncStorage_db_size_in_MB=10

--- a/packages/default-storage/package.json
+++ b/packages/default-storage/package.json
@@ -11,6 +11,7 @@
     "android/build.gradle",
     "android/src",
     "android/testresults.gradle",
+    "android/config.gradle",
     "ios/",
     "jest/",
     "lib/",

--- a/packages/default-storage/package.json
+++ b/packages/default-storage/package.json
@@ -98,7 +98,7 @@
     "react-native-builder-bob": "^0.18.0",
     "react-native-codegen": "^0.71.5",
     "react-native-macos": "^0.71.0",
-    "react-native-test-app": "^2.5.8",
+    "react-native-test-app": "^2.5.33",
     "react-native-web": "~0.18.10",
     "react-native-windows": "^0.71.0",
     "react-test-renderer": "18.2.0",

--- a/packages/default-storage/package.json
+++ b/packages/default-storage/package.json
@@ -8,10 +8,9 @@
   "types": "lib/typescript/index.d.ts",
   "files": [
     "RNCAsyncStorage.podspec",
-    "android/build.gradle",
-    "android/src",
-    "android/testresults.gradle",
-    "android/config.gradle",
+    "android/",
+    "!android/.gradle",
+    "!android/build",
     "ios/",
     "jest/",
     "lib/",

--- a/packages/website/docs/advanced/Next.md
+++ b/packages/website/docs/advanced/Next.md
@@ -47,19 +47,19 @@ AsyncStorage_useNextStorage=true
 
 **Kotlin version**
 
-Next storage is tested against Kotlin version `1.8.10`. 
+Next storage is tested against Kotlin version `1.9.20`. 
 You can specify different version, in one of two ways:
 
 - add `kotlinVersion` extension to the `rootProject`:
 
 ```groovy
-rootProject.ext.kotlinVersion = '1.8.10'
+rootProject.ext.kotlinVersion = '1.9.20'
 ```
 
 - specify `AsyncStorage_kotlinVersion` in `gradle.properties`:
 
 ```groovy
-AsyncStorage_kotlinVersion=1.8.10
+AsyncStorage_kotlinVersion=1.9.20
 ```
 
 **Room**
@@ -69,6 +69,13 @@ Currently, tested version is `2.4.3`. You can specify different version, by addi
 
 ```groovy
 AsyncStorage_next_roomVersion=2.4.3
+```
+
+KSP is enabled for symbol processing for Room.
+If you use different Kotlin version than default, you should also [update KSP version](https://github.com/google/ksp/releases) to keep compatibility:
+
+```groovy
+AsyncStorage_next_kspVersion=1.9.20-1.0.14
 ```
 
 ### Notable changes

--- a/packages/website/docs/advanced/Next.md
+++ b/packages/website/docs/advanced/Next.md
@@ -71,8 +71,9 @@ Currently, tested version is `2.4.3`. You can specify different version, by addi
 AsyncStorage_next_roomVersion=2.4.3
 ```
 
-KSP is enabled for symbol processing for Room.
-If you use different Kotlin version than default, you should also [update KSP version](https://github.com/google/ksp/releases) to keep compatibility:
+KSP is enabled for symbol processing for the Room library.
+KSP version will be selected based on Kotlin version in your project.
+If you want to use different KSP version, you can set a property in `gradle.properties`:
 
 ```groovy
 AsyncStorage_next_kspVersion=1.9.20-1.0.14

--- a/yarn.lock
+++ b/yarn.lock
@@ -4159,7 +4159,7 @@ __metadata:
     react-native-builder-bob: ^0.18.0
     react-native-codegen: ^0.71.5
     react-native-macos: ^0.71.0
-    react-native-test-app: ^2.5.8
+    react-native-test-app: ^2.5.33
     react-native-web: ~0.18.10
     react-native-windows: ^0.71.0
     react-test-renderer: 18.2.0
@@ -4524,12 +4524,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rnx-kit/react-native-host@npm:^0.2.7":
-  version: 0.2.7
-  resolution: "@rnx-kit/react-native-host@npm:0.2.7"
+"@rnx-kit/react-native-host@npm:^0.2.8":
+  version: 0.2.9
+  resolution: "@rnx-kit/react-native-host@npm:0.2.9"
   peerDependencies:
     react-native: ">=0.64"
-  checksum: 67570885718da085f33512defbd56878f9b745ea5bd16a1c5854054d0d85874ad1fdd5f17909960301709d17fa7e35dcccfb428c817c92bcfa486fb80ac010de
+  checksum: 1d7678930cd59b6ca84b9858ef0834991f89909df0a4f8176592d967d921d547405431f7518803b29bc4cb1bddc722898c42758b2a8889df11f0550283dff146
   languageName: node
   linkType: hard
 
@@ -20254,11 +20254,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-test-app@npm:^2.5.8":
-  version: 2.5.8
-  resolution: "react-native-test-app@npm:2.5.8"
+"react-native-test-app@npm:^2.5.33":
+  version: 2.5.33
+  resolution: "react-native-test-app@npm:2.5.33"
   dependencies:
-    "@rnx-kit/react-native-host": ^0.2.7
+    "@rnx-kit/react-native-host": ^0.2.8
     ajv: ^8.0.0
     chalk: ^4.1.0
     cliui: ^8.0.0
@@ -20269,24 +20269,12 @@ __metadata:
     uuid: ^8.3.2
   peerDependencies:
     "@expo/config-plugins": ">=5.0"
-    "@react-native-community/cli": ">=5.0"
-    "@react-native-community/cli-platform-android": ">=5.0"
-    "@react-native-community/cli-platform-ios": ">=5.0"
-    mustache: ^4.0.0
     react: ~17.0.1 || ~18.0.0 || ~18.1.0 || ~18.2.0
     react-native: ^0.0.0-0 || 0.64 - 0.72 || 1000.0.0
-    react-native-macos: ^0.0.0-0 || 0.64 || 0.66 || 0.68 || 0.71
+    react-native-macos: ^0.0.0-0 || 0.64 || 0.66 || 0.68 || 0.71 - 0.72
     react-native-windows: ^0.0.0-0 || 0.64 - 0.72
   peerDependenciesMeta:
     "@expo/config-plugins":
-      optional: true
-    "@react-native-community/cli":
-      optional: true
-    "@react-native-community/cli-platform-android":
-      optional: true
-    "@react-native-community/cli-platform-ios":
-      optional: true
-    mustache:
       optional: true
     react-native-macos:
       optional: true
@@ -20297,7 +20285,7 @@ __metadata:
     init: scripts/init.js
     init-test-app: scripts/init.js
     install-windows-test-app: windows/test-app.js
-  checksum: f23c468daf2b388b84fc6650c569b3661907680da63ce4be1a2c8d5220ea4cb12aca3add13a1ccba77d98251e62a853cade0ff8acf2eb0bcda50e3e819e7dbbf
+  checksum: 96e9d78b44c3cb620e11b02177660e859a652f7ff492580f93d5ac7e38af0114c85540087b62a7b9b4347373cb5cd9f411f2c97b90b16dc9fb0e37ebe8635b0e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- Bumped default Kotlin version to 1.9.20
- Coroutines bumped to 1.7.3
- Dropped `kapt` in favor of `ksp`, which version can be set via gradle property