### PR TITLE
docs: fix incorrect anchor link casing

### DIFF
--- a/packages/website/docs/API.md
+++ b/packages/website/docs/API.md
@@ -461,7 +461,7 @@ removeFew = async () => {
 
 ## `clear`
 
-Removes **whole** `AsyncStorage` data, for all clients, libraries, etc. You probably want to use [removeItem](#removeItem) or [multiRemove](#multiRemove) to clear only your App's keys.
+Removes **whole** `AsyncStorage` data, for all clients, libraries, etc. You probably want to use [removeItem](#removeitem) or [multiRemove](#multiremove) to clear only your App's keys.
 
 **Signature**:
 


### PR DESCRIPTION
## Summary
This pull request corrects two broken anchor links within the documentation: the links to `#removeItem` and `#multiRemove` subsections in the [clear method](https://react-native-async-storage.github.io/async-storage/docs/api/#clear).

## Changes
- Updated the anchor link reference from `#removeItem` to `#removeitem` in `API.md`
- Updated the anchor link reference from `#multiRemove` to `#multiremove` in `API.md`

## Test Plan

- Tested locally on Brave Version 1.61.114 Chromium: 120.0.6099.199 (Official Build)  (64-bit)