### PR TITLE
feat: add visionOS support

### DIFF
--- a/packages/default-storage/RNCAsyncStorage.podspec
+++ b/packages/default-storage/RNCAsyncStorage.podspec
@@ -23,7 +23,7 @@ Pod::Spec.new do |s|
       'HEADER_SEARCH_PATHS' => '"$(PODS_ROOT)/boost" "$(PODS_ROOT)/boost-for-react-native" "$(PODS_ROOT)/RCT-Folly"',
       'CLANG_CXX_LANGUAGE_STANDARD' => 'c++17',
     }
-    s.platforms       = { ios: '13.4', tvos: '11.0', :osx => "10.15" }
+    s.platforms       = { ios: '13.4', tvos: '11.0', :osx => "10.15", :visionos => "1.0" }
     s.compiler_flags  = folly_compiler_flags + ' -DRCT_NEW_ARCH_ENABLED=1'
 
     if respond_to?(:install_modules_dependencies, true)
@@ -37,7 +37,7 @@ Pod::Spec.new do |s|
       s.dependency "ReactCommon/turbomodule/core"
     end
   else
-    s.platforms = { :ios => "9.0", :tvos => "9.2", :osx => "10.14" }
+    s.platforms = { :ios => "9.0", :tvos => "9.2", :osx => "10.14", :visionos => "1.0" }
 
     s.dependency "React-Core"
   end


### PR DESCRIPTION
## Summary

<!--
  Thank you for submitting a PR!

  Help us understand more of your work - you can explain what you did, post a
  link to an issue, screenshots etc. Anything helps!
-->

Closes #1062 

This PR adds support for [React Native visionOS](https://github.com/callstack/react-native-visionos), the new out-of-tree platform.

![image](https://github.com/react-native-async-storage/async-storage/assets/26878038/57b81955-8a47-4fd5-aaa7-30abb7588cdf)

## Test Plan

<!--
    Help us test your work (**REQUIRED**).

    If you changed the code, please provide us with instructions of how we can
    try it out ourselves, so we can confirm it's working. You can also post
    screenshots/gifts.
-->

You can init a new project with [React Native visionOS](https://github.com/callstack/react-native-visionos), install the library as usual (and apply the one-line change in this PR) and all APIs should be working.

All the APIs used here are already supported in visionOS, so it's just a matter of adding the platform to the podspec for it to get installed.

All the tests still pass. No actual change in C or JS files.