### PR TITLE
fix(ios): Merging empty object should not override current value

### DIFF
--- a/packages/default-storage/README.md
+++ b/packages/default-storage/README.md
@@ -35,7 +35,7 @@ to learn more.
 2. Build app and run tests
    ```shell
    yarn bundle:ios
-   (cd example/ios && pod install)
+   pod install --project-directory=example/ios
    yarn build:e2e:ios
    yarn test:e2e:ios
    ```

--- a/packages/default-storage/README.md
+++ b/packages/default-storage/README.md
@@ -35,6 +35,7 @@ to learn more.
 2. Build app and run tests
    ```shell
    yarn bundle:ios
+   (cd example/ios && pod install)
    yarn build:e2e:ios
    yarn test:e2e:ios
    ```

--- a/packages/default-storage/example/examples/Functional.tsx
+++ b/packages/default-storage/example/examples/Functional.tsx
@@ -79,19 +79,21 @@ async function executeStep(step: TestStep): Promise<void> {
 
 async function execute(steps: TestStep[]): Promise<void> {
   const numSteps = steps.length;
-  for (let i = 0; i < numSteps; ++i) {
-    try {
-      await executeStep(steps[i]);
-    } catch (e) {
-      if (!Array.isArray(e)) {
-        throw e;
-      }
+  try {
+    for (let i = 0; i < numSteps; ++i) {
+      try {
+        await executeStep(steps[i]);
+      } catch (e) {
+        if (!Array.isArray(e)) {
+          throw e;
+        }
 
-      const [expected, actual] = e;
-      throw { step: i, expected, actual };
-    } finally {
-      await AsyncStorage.clear();
+        const [expected, actual] = e;
+        throw { step: i, expected, actual };
+      }
     }
+  } finally {
+    await AsyncStorage.clear();
   }
 }
 

--- a/packages/default-storage/example/examples/tests.ts
+++ b/packages/default-storage/example/examples/tests.ts
@@ -50,7 +50,7 @@ const tests: Record<string, TestStep[]> = {
       },
     },
   ],
-  "Should merge items #2": [
+  "Should keep existing entries when merging with an empty object": [
     {
       command: "set",
       key: "merge_test_2",

--- a/packages/default-storage/example/examples/tests.ts
+++ b/packages/default-storage/example/examples/tests.ts
@@ -13,7 +13,7 @@ export type TestStep =
     };
 
 const tests: Record<string, TestStep[]> = {
-  "Should store value in AsyncStorage": [
+  "Should store value": [
     { command: "set", key: "a", value: "0" },
     { command: "set", key: "a", value: "10" },
     { command: "set", key: "a", value: "20" },
@@ -31,8 +31,7 @@ const tests: Record<string, TestStep[]> = {
       value: {
         name: "Jerry",
         age: "21",
-        eyesColor: "blue",
-        shoeSize: "9",
+        shoeSize: "10",
       },
     },
     {
@@ -42,7 +41,35 @@ const tests: Record<string, TestStep[]> = {
         name: "Sarah",
         age: "23",
         eyesColor: "green",
+      },
+      expected: {
+        name: "Sarah",
+        age: "23",
+        eyesColor: "green",
         shoeSize: "10",
+      },
+    },
+  ],
+  "Should merge items #2": [
+    {
+      command: "set",
+      key: "merge_test_2",
+      value: {
+        name: "Jerry",
+        age: "21",
+        eyesColor: "blue",
+        shoeSize: "9",
+      },
+    },
+    {
+      command: "merge",
+      key: "merge_test_2",
+      value: {},
+      expected: {
+        name: "Jerry",
+        age: "21",
+        eyesColor: "blue",
+        shoeSize: "9",
       },
     },
   ],

--- a/packages/default-storage/example/ios/AsyncStorageExample/AsyncStorageDevSupport.m
+++ b/packages/default-storage/example/ios/AsyncStorageExample/AsyncStorageDevSupport.m
@@ -71,11 +71,19 @@ static AsyncStorageDevSupport *_sharedInstance;
          completion:(RNCAsyncStorageResultCallback)completion
 {
     NSError *error = nil;
-    NSDictionary *dictionary =
+    NSMutableDictionary *destination = [NSJSONSerialization
+        JSONObjectWithData:[_memoryStorage[keys[0]] dataUsingEncoding:NSUTF8StringEncoding]
+                   options:NSJSONReadingMutableContainers
+                     error:&error];
+
+    NSDictionary *source =
         [NSJSONSerialization JSONObjectWithData:[values[0] dataUsingEncoding:NSUTF8StringEncoding]
                                         options:NSJSONReadingMutableContainers
                                           error:&error];
-    NSData *data = [NSJSONSerialization dataWithJSONObject:dictionary options:0 error:&error];
+
+    [destination addEntriesFromDictionary:source];
+
+    NSData *data = [NSJSONSerialization dataWithJSONObject:destination options:0 error:&error];
     NSString *str = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
     _memoryStorage[keys[0]] = str;
     completion(@[str]);

--- a/packages/default-storage/ios/RNCAsyncStorage.mm
+++ b/packages/default-storage/ios/RNCAsyncStorage.mm
@@ -787,7 +787,8 @@ RCT_EXPORT_METHOD(multiMerge:(NSArray<NSArray<NSString *> *> *)kvPairs
             if (value) {
                 NSError *jsonError;
                 NSMutableDictionary *mergedVal = RCTJSONParseMutable(value, &jsonError);
-                if (RCTMergeRecursive(mergedVal, RCTJSONParse(entry[1], &jsonError))) {
+                NSDictionary *mergingValue = RCTJSONParse(entry[1], &jsonError);
+                if (!mergingValue.count || RCTMergeRecursive(mergedVal, mergingValue)) {
                     entry = @[entry[0], RCTNullIfNil(RCTJSONStringify(mergedVal, NULL))];
                 }
                 if (jsonError) {

--- a/packages/default-storage/scripts/ios_e2e.sh
+++ b/packages/default-storage/scripts/ios_e2e.sh
@@ -1,10 +1,5 @@
 #!/bin/bash
 
-RESOURCE_DIR="$PWD/example/ios/build/Build/Products/Release-iphonesimulator/ReactTestApp.app"
-ENTRY_FILE="example/index.ts"
-BUNDLE_FILE="$RESOURCE_DIR/index.ios.jsbundle"
-EXTRA_PACKAGER_ARGS="--entry-file=$ENTRY_FILE"
-
 build_project() {
   echo "[iOS E2E] Building iOS project"
   eval "xcodebuild \
@@ -12,9 +7,7 @@ build_project() {
     -scheme ReactTestApp \
     -configuration Release \
     -sdk iphonesimulator \
-    -derivedDataPath example/ios/build \
-    BUNDLE_FILE=$BUNDLE_FILE \
-    EXTRA_PACKAGER_ARGS=$EXTRA_PACKAGER_ARGS"
+    -derivedDataPath example/ios/build"
 }
 
 bundle_js() {


### PR DESCRIPTION
## Summary

Passing an empty object to `multiMerge` avoided looping over keys to compare/merge. If the provided object is empty now, simply use the original object instead.

Closes #1046 