### PR TITLE
fix: check directory before call delete on iOS

### DIFF
--- a/packages/default-storage/ios/RNCAsyncStorage.mm
+++ b/packages/default-storage/ios/RNCAsyncStorage.mm
@@ -250,6 +250,9 @@ static NSDictionary *RCTDeleteStorageDirectory()
     NSError *error;
     [[NSFileManager defaultManager] removeItemAtPath:RCTGetStorageDirectory() error:&error];
     RCTHasCreatedStorageDirectory = NO;
+    if (error.code == NSFileNoSuchFileError) {
+        return nil;
+    }
     return error ? RCTMakeError(@"Failed to delete storage directory.", error, nil) : nil;
 }
 
@@ -869,14 +872,8 @@ RCT_EXPORT_METHOD(clear:(RCTResponseSenderBlock)callback)
 
     [_manifest removeAllObjects];
     [RCTGetCache() removeAllObjects];
-    
-    NSFileManager *fileManager = [NSFileManager defaultManager];
-    if ([fileManager fileExistsAtPath:RCTGetStorageDirectory()]) {
-        NSDictionary *error = RCTDeleteStorageDirectory();
-        callback(@[RCTNullIfNil(error)]);
-    } else {
-        callback(@[[NSNull null]]);
-    }
+    NSDictionary *error = RCTDeleteStorageDirectory();
+    callback(@[RCTNullIfNil(error)]);
 }
 
 // clang-format off

--- a/packages/default-storage/ios/RNCAsyncStorage.mm
+++ b/packages/default-storage/ios/RNCAsyncStorage.mm
@@ -869,8 +869,14 @@ RCT_EXPORT_METHOD(clear:(RCTResponseSenderBlock)callback)
 
     [_manifest removeAllObjects];
     [RCTGetCache() removeAllObjects];
-    NSDictionary *error = RCTDeleteStorageDirectory();
-    callback(@[RCTNullIfNil(error)]);
+    
+    NSFileManager *fileManager = [NSFileManager defaultManager];
+    if ([fileManager fileExistsAtPath:RCTGetStorageDirectory()]) {
+        NSDictionary *error = RCTDeleteStorageDirectory();
+        callback(@[RCTNullIfNil(error)]);
+    } else {
+        callback(@[[NSNull null]]);
+    }
 }
 
 // clang-format off

--- a/packages/default-storage/ios/RNCAsyncStorage.mm
+++ b/packages/default-storage/ios/RNCAsyncStorage.mm
@@ -250,10 +250,10 @@ static NSDictionary *RCTDeleteStorageDirectory()
     NSError *error;
     [[NSFileManager defaultManager] removeItemAtPath:RCTGetStorageDirectory() error:&error];
     RCTHasCreatedStorageDirectory = NO;
-    if (error.code == NSFileNoSuchFileError) {
-        return nil;
+    if (error && error.code != NSFileNoSuchFileError) {
+        return RCTMakeError(@"Failed to delete storage directory.", error, nil);
     }
-    return error ? RCTMakeError(@"Failed to delete storage directory.", error, nil) : nil;
+    return nil;
 }
 
 static NSDate *RCTManifestModificationDate(NSString *manifestFilePath)


### PR DESCRIPTION
## Summary

Before executing the `clear` method on iOS, check if the directory exists using `RCTGetStorageDirectory` to avoid throwing an error.

Fixes #1020 

## Test Plan

To test this change I created an app from scratch and call `await AsyncStorage.clear()`.
The component code is available on [gist](https://gist.github.com/camilossantos2809/94af62fd65dce53d1cf77430369cbf92)

before:

https://github.com/react-native-async-storage/async-storage/assets/20076881/0a7e7881-6404-4260-bc58-d23179b29f18

after:

https://github.com/react-native-async-storage/async-storage/assets/20076881/5cafc379-839d-45cf-9c0b-76a2855358e0


