### PR TITLE
fix(android): bridgeless mode broken on react-native 0.74

### DIFF
--- a/packages/default-storage/android/build.gradle
+++ b/packages/default-storage/android/build.gradle
@@ -62,6 +62,7 @@ android {
         buildConfigField "Long", "AsyncStorage_db_size", "${project.ext.AsyncStorageConfig.databaseSizeMB}L"
         buildConfigField "boolean", "AsyncStorage_useDedicatedExecutor", "${project.ext.AsyncStorageConfig.useDedicatedExecutor}"
         buildConfigField "boolean", "AsyncStorage_useNextStorage", "${useNextStorage}"
+        buildConfigField "boolean", "IS_NEW_ARCHITECTURE_ENABLED", "${isNewArchitectureEnabled}"
     }
     lintOptions {
         abortOnError false

--- a/packages/default-storage/android/src/javaPackage/java/com/reactnativecommunity/asyncstorage/AsyncStoragePackage.java
+++ b/packages/default-storage/android/src/javaPackage/java/com/reactnativecommunity/asyncstorage/AsyncStoragePackage.java
@@ -8,7 +8,6 @@
 package com.reactnativecommunity.asyncstorage;
 
 import com.facebook.react.TurboReactPackage;
-import com.facebook.react.ViewManagerOnDemandReactPackage;
 import com.facebook.react.bridge.ModuleSpec;
 import com.facebook.react.bridge.JavaScriptModule;
 import com.facebook.react.bridge.NativeModule;
@@ -17,7 +16,6 @@ import com.facebook.react.module.annotations.ReactModule;
 import com.facebook.react.module.annotations.ReactModuleList;
 import com.facebook.react.module.model.ReactModuleInfo;
 import com.facebook.react.module.model.ReactModuleInfoProvider;
-import com.facebook.react.turbomodule.core.interfaces.TurboModule;
 import com.facebook.react.uimanager.ViewManager;
 import java.util.Collections;
 import java.util.HashMap;
@@ -25,7 +23,6 @@ import java.util.List;
 import java.util.Map;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 
 @ReactModuleList(
         nativeModules = {
@@ -62,6 +59,7 @@ public class AsyncStoragePackage extends TurboReactPackage {
                 @Override
                 public Map<String, ReactModuleInfo> getReactModuleInfos() {
                     final Map<String, ReactModuleInfo> reactModuleInfoMap = new HashMap<>();
+                    boolean isTurboModule = BuildConfig.IS_NEW_ARCHITECTURE_ENABLED;
 
                     Class<? extends NativeModule>[] moduleList =
                             new Class[] {
@@ -80,7 +78,7 @@ public class AsyncStoragePackage extends TurboReactPackage {
                                         reactModule.needsEagerInit(),
                                         reactModule.hasConstants(),
                                         reactModule.isCxxModule(),
-                                        TurboModule.class.isAssignableFrom(moduleClass)));
+                                        isTurboModule));
                     }
 
                     return reactModuleInfoMap;
@@ -90,11 +88,6 @@ public class AsyncStoragePackage extends TurboReactPackage {
             throw new RuntimeException(
                     "No ReactModuleInfoProvider for com.reactnativecommunity.asyncstorage.AsyncStoragePackage$$ReactModuleInfoProvider", e);
         }
-    }
-
-    // Deprecated in RN 0.47 
-    public List<Class<? extends JavaScriptModule>> createJSModules() {
-        return Collections.emptyList();
     }
 
     @Override

--- a/packages/default-storage/android/src/kotlinPackage/java/com/reactnativecommunity/asyncstorage/AsyncStoragePackage.kt
+++ b/packages/default-storage/android/src/kotlinPackage/java/com/reactnativecommunity/asyncstorage/AsyncStoragePackage.kt
@@ -1,7 +1,6 @@
 package com.reactnativecommunity.asyncstorage
 
 import com.facebook.react.TurboReactPackage
-import com.facebook.react.ViewManagerOnDemandReactPackage
 import com.facebook.react.bridge.ModuleSpec
 import com.facebook.react.bridge.NativeModule
 import com.facebook.react.bridge.ReactApplicationContext
@@ -9,9 +8,6 @@ import com.facebook.react.module.annotations.ReactModule
 import com.facebook.react.module.annotations.ReactModuleList
 import com.facebook.react.module.model.ReactModuleInfo
 import com.facebook.react.module.model.ReactModuleInfoProvider
-import com.facebook.react.turbomodule.core.interfaces.TurboModule
-import com.facebook.react.uimanager.ReactShadowNode
-import com.facebook.react.uimanager.ViewManager
 import com.reactnativecommunity.asyncstorage.next.StorageModule
 
 @ReactModuleList(
@@ -32,10 +28,11 @@ class AsyncStoragePackage : TurboReactPackage() {
             return reactModuleInfoProviderClass.newInstance() as ReactModuleInfoProvider
         } catch (e: ClassNotFoundException) {
             return ReactModuleInfoProvider {
+                val isTurboModule = BuildConfig.IS_NEW_ARCHITECTURE_ENABLED
                 val reactModule: ReactModule = StorageModule::class.java.getAnnotation(
                     ReactModule::class.java)!!
 
-                mutableMapOf(
+                mapOf(
                     StorageModule.NAME to ReactModuleInfo(
                         reactModule.name,
                         StorageModule::class.java.name,
@@ -43,7 +40,7 @@ class AsyncStoragePackage : TurboReactPackage() {
                         reactModule.needsEagerInit,
                         reactModule.hasConstants,
                         reactModule.isCxxModule,
-                        TurboModule::class.java.isAssignableFrom(StorageModule::class.java)
+                        isTurboModule
                     )
                 )
             }


### PR DESCRIPTION
## Summary

This PR tries to fix the `[@RNC/AsyncStorage]: NativeModule: AsyncStorage is null` error when running on react-native@0.74.0-rc.1. The regression was coming from https://github.com/facebook/react-native/pull/41412 and https://github.com/facebook/react-native/issues/43213 has more discussion. This PR follows the [create-react-native-library template to rely on BuildConfig](https://github.com/callstack/react-native-builder-bob/blob/aa4d72367b6dae098cc38f10b04e19daf3499249/packages/create-react-native-library/templates/kotlin-library-mixed/android/src/main/java/com/%7B%25-%20project.package_dir%20%25%7D/%7B%25-%20project.name%20%25%7DPackage.kt#L22)

## Test Plan

```sh
$ npx @react-native-community/cli@latest init RN074 --version next
$ cd RN074
$ yarn add @react-native-async-storage/async-storage
# edit App.tsx for using async-storage
$ cd android
$ ./gradlew -PnewArchEnabled=true :app:installDebug
$ ./gradlew -PnewArchEnabled=true -PAsyncStorage_useNextStorage=true :app:installDebug
```