### PR TITLE
fix(default-storage): Privacy manifest missing key

### DIFF
--- a/packages/default-storage/ios/PrivacyInfo.xcprivacy
+++ b/packages/default-storage/ios/PrivacyInfo.xcprivacy
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
 	<key>NSPrivacyAccessedAPITypes</key>
 	<array>
 		<dict>


### PR DESCRIPTION
## Summary

Apparently, even if the SDK does not collect any data, the Privacy manifest **requires** that entry to be there, even if with an empty array ¯\_(ツ)_/¯