### PR TITLE
[windows] Add ReactPropertyBag option for DB path initialization

### DIFF
--- a/packages/default-storage/windows/code/DBStorage.cpp
+++ b/packages/default-storage/windows/code/DBStorage.cpp
@@ -238,9 +238,13 @@ DBStorage::InitializeStorage(DBStorage::ErrorManager &errorManager) noexcept
 
     std::string path;
     try {
-        if (auto pathInspectable =
+        if (m_path != L"") {
+            path = winrt::to_string(m_path);
+#ifndef USE_WINUI3
+        } else if (auto pathInspectable =
                 winrt::CoreApplication::Properties().TryLookup(s_dbPathProperty)) {
             path = winrt::to_string(winrt::unbox_value<winrt::hstring>(pathInspectable));
+#endif
         } else {
             auto const localAppDataPath = winrt::ApplicationData::Current().LocalFolder().Path();
             path = winrt::to_string(localAppDataPath) + "\\AsyncStorage.db";

--- a/packages/default-storage/windows/code/DBStorage.h
+++ b/packages/default-storage/windows/code/DBStorage.h
@@ -142,6 +142,10 @@ struct DBStorage {
 
     winrt::Windows::Foundation::IAsyncAction RunTasks() noexcept;
 
+    void Path(const winrt::hstring &path) noexcept {
+        m_path = path;
+    }
+
 private:
     static constexpr auto s_dbPathProperty = L"React-Native-Community-Async-Storage-Database-Path";
 
@@ -150,6 +154,7 @@ private:
     winrt::slim_condition_variable m_cv;
     winrt::Windows::Foundation::IAsyncAction m_action{nullptr};
     std::vector<std::unique_ptr<DBTask>> m_tasks;
+    winrt::hstring m_path{L""};
 };
 
 void ReadValue(const winrt::Microsoft::ReactNative::IJSValueReader &reader,

--- a/packages/default-storage/windows/code/RNCAsyncStorage.h
+++ b/packages/default-storage/windows/code/RNCAsyncStorage.h
@@ -10,6 +10,16 @@ namespace winrt::ReactNativeAsyncStorage::implementation
     REACT_MODULE(RNCAsyncStorage)
     struct RNCAsyncStorage {
 
+        REACT_INIT(Initialize)
+        void Initialize(winrt::Microsoft::ReactNative::ReactContext const &reactContext) noexcept
+        {
+            winrt::Microsoft::ReactNative::ReactPropertyId<winrt::hstring> propId{L"ReactNativeAsyncStorage", L"Path"};
+            const auto path = reactContext.Properties().Get(propId);
+            if (path.has_value()) {
+                m_dbStorage.Path(path.value());
+            }
+        }
+
         REACT_METHOD(multiGet)
         void multiGet(
             std::vector<std::string> &&keys,


### PR DESCRIPTION


## Summary

WinAppSDK apps do not support the current methods for setting / retrieving the DB path for the default storage in @react-native-async-storage/async-storage. Specifically, winrt::CoreApplication::Properties() causes a crashes on WinAppSDK.

To work around this, this change adds a specific namespaced key (ReactNativeAsyncStorage.Path) to the ReactPropertyBag for apps to register the overridden DB path for WinAppSDK apps (or apps that otherwise cannot use winrt::CoreApplication::Properties()).

## Test Plan

Compiled with WinAppSDK build of react-native-windows, set ReactNativeAsyncStorage.Path on the ReactPropertyBag for InstanceSettings when initializing the react-native-windows ReactHost, and confirmed the sqlite DB is written to the correct location.
