### PR TITLE
fix: Remove internal references of onCatalystInstanceDestroy()

### DIFF
--- a/packages/default-storage/android/src/main/java/com/reactnativecommunity/asyncstorage/AsyncStorageModule.java
+++ b/packages/default-storage/android/src/main/java/com/reactnativecommunity/asyncstorage/AsyncStorageModule.java
@@ -81,7 +81,7 @@ public final class AsyncStorageModule
   }
 
   @Override
-  public void onCatalystInstanceDestroy() {
+  public void invalidate() {
     mShuttingDown = true;
   }
 


### PR DESCRIPTION
## Summary

#1106 

## Test Plan

![image](https://github.com/react-native-async-storage/async-storage/assets/20939091/7453cbdd-cd01-44bf-8d70-0ccc02220b71)

