### PR TITLE
chore: recommend Expo Discord over read-only forums in issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
-  - name: I use Expo
-    url: https://forums.expo.dev/tag/asyncstorage
-    about: I have issues with AsyncStorage and Expo.
+  - name: I use Expo and I have issues with AsyncStorage.
+    url: https://discord.com/invite/expo
+    about: Visit Expo Discord to discuss your problem.


### PR DESCRIPTION
## Summary

Our forums are in read-only mode for a while, the Discord servers and channels and forums in there are a recommended way to get in touch with us, and other users.

## Test Plan

N/A - forks do not show origin issue templates.
