### PR TITLE
chore: add visionOS to README platforms list

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Native.
 - Android
 - iOS
 - [macOS](https://github.com/react-native-async-storage/async-storage/releases/tag/v1.8.1)
+- [visionOS](https://github.com/react-native-async-storage/async-storage/releases/tag/v1.22.0)
 - [Web](https://github.com/react-native-async-storage/async-storage/releases/tag/v1.9.0)
 - [Windows](https://github.com/react-native-async-storage/async-storage/releases/tag/v1.10.0)
 


### PR DESCRIPTION
## Summary

Refs:
* https://github.com/react-native-async-storage/async-storage/pull/1063

## Test Plan

Markdown has been tested in in-browser commit preview.

![Screenshot 2024-06-26 104822](https://github.com/react-native-async-storage/async-storage/assets/719641/a45b0e63-a29a-4cb1-bc31-1006e51d2742)
