### PR TITLE
chore: trigger release for previous chore commits

### DIFF
--- a/.changeset/mighty-trains-lick.md
+++ b/.changeset/mighty-trains-lick.md
@@ -1,0 +1,5 @@
+---
+"@react-native-async-storage/async-storage": minor
+---
+
+dependencies bump and multiset type fix

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test:ts": "turbo run test:ts",
     "test:format": "prettier --check --loglevel warn $(git ls-files '*.js' '*.json' '*.ts' '*.tsx' '*.yml' 'README.md')",
     "release:version": "changeset version",
-    "release:publish": "changeset release"
+    "release:publish": "changeset publish"
   },
   "devDependencies": {
     "@changesets/changelog-github": "^0.5.0",


### PR DESCRIPTION
## Summary

That includes [native dependencies bump](https://github.com/react-native-async-storage/async-storage/pull/1094), [type fix for multiSet](https://github.com/react-native-async-storage/async-storage/pull/1103) and some internal dependencies bump
