### PR TITLE
chore: yet another follow up for changesets release

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -12,6 +12,8 @@
   "updateInternalDependencies": "patch",
   "ignore": [
     "@react-native-async-storage/eslint-config",
-    "async-storage-website"
+    "async-storage-website",
+    "@react-native-async-storage/api",
+    "@react-native-async-storage/sqlite-storage"
   ]
 }

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,9 +1,6 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@3.0.2/schema.json",
-  "changelog": [
-    "@changesets/changelog-github",
-    { "repo": "react-native-async-storage/async-storage" }
-  ],
+  "changelog": "@changesets/cli/changelog",
   "commit": ["@changesets/cli/commit", { "skipCI": false }],
   "fixed": [],
   "linked": [],

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,6 @@ jobs:
           version: "yarn release:version"
         env:
           GITHUB_TOKEN: ${{ secrets.GH_RELEASE_TOKEN }}
-          GITHUB_NAME: ${{ secrets.GH_BOT_NAME }}
-          GITHUB_EMAIL: ${{ secrets.GH_BOT_EMAIL }}
+          GITHUB_NAME: ${{ vars.GH_BOT_NAME }}
+          GITHUB_EMAIL: ${{ vars.GH_BOT_EMAIL }}
           NPM_TOKEN: ${{ secrets.NPM_RELEASE_TOKEN }}

--- a/.github/workflows/website-deployment.yml
+++ b/.github/workflows/website-deployment.yml
@@ -24,10 +24,10 @@ jobs:
         working-directory: ./.github/scripts
         env:
           GITHUB_TOKEN: ${{ secrets.GH_RELEASE_TOKEN }}
-          GITHUB_NAME: ${{ secrets.GH_BOT_NAME }}
-          GITHUB_EMAIL: ${{ secrets.GH_BOT_EMAIL }}
+          GITHUB_NAME: ${{ vars.GH_BOT_NAME }}
+          GITHUB_EMAIL: ${{ vars.GH_BOT_EMAIL }}
       - name: Deploy
         env:
-          GIT_USER: ${{ secrets.GH_BOT_NAME }}
+          GIT_USER: ${{ vars.GH_BOT_NAME }}
         run: yarn run deploy
         working-directory: ./packages/website

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "release:publish": "./.github/scripts/setup-ci-git-user.sh && changeset publish"
   },
   "devDependencies": {
-    "@changesets/changelog-github": "^0.5.0",
     "@changesets/cli": "^2.27.7",
     "concurrently": "^8.2.2",
     "eslint": "^8.54.0",

--- a/packages/default-storage/CHANGELOG.md
+++ b/packages/default-storage/CHANGELOG.md
@@ -1,313 +1,273 @@
-## [1.23.2](https://github.com/react-native-async-storage/async-storage/compare/v1.23.1...v1.23.2) (2024-06-17)
+# Change Log
 
+## 1.23.2
+
+> [!WARNING]  
+> This version has not been released to npm
 
 ### Bug Fixes
 
-* `multiSet` should expect read-only input ([#1103](https://github.com/react-native-async-storage/async-storage/issues/1103)) ([9993f6e](https://github.com/react-native-async-storage/async-storage/commit/9993f6ec14353f1f41f361003b564e8f5461e72e))
+- `multiSet` should expect read-only input ([#1103](https://github.com/react-native-async-storage/async-storage/issues/1103)) ([9993f6e](https://github.com/react-native-async-storage/async-storage/commit/9993f6ec14353f1f41f361003b564e8f5461e72e))
 
 ## [1.23.1](https://github.com/react-native-async-storage/async-storage/compare/v1.23.0...v1.23.1) (2024-03-20)
 
-
 ### Bug Fixes
 
-* **default-storage:** Privacy manifest missing key ([#1076](https://github.com/react-native-async-storage/async-storage/issues/1076)) ([c4ed1fa](https://github.com/react-native-async-storage/async-storage/commit/c4ed1fa2fd1541ad26a06f937af4438158aa15df))
+- **default-storage:** Privacy manifest missing key ([#1076](https://github.com/react-native-async-storage/async-storage/issues/1076)) ([c4ed1fa](https://github.com/react-native-async-storage/async-storage/commit/c4ed1fa2fd1541ad26a06f937af4438158aa15df))
 
 # [1.23.0](https://github.com/react-native-async-storage/async-storage/compare/v1.22.3...v1.23.0) (2024-03-19)
 
-
 ### Features
 
-* **default-storage:** Add Privacy Manifest for iOS ([#1075](https://github.com/react-native-async-storage/async-storage/issues/1075)) ([864626d](https://github.com/react-native-async-storage/async-storage/commit/864626d6d8a2c85a7ddf38c0a9c512db64fcdf06))
+- **default-storage:** Add Privacy Manifest for iOS ([#1075](https://github.com/react-native-async-storage/async-storage/issues/1075)) ([864626d](https://github.com/react-native-async-storage/async-storage/commit/864626d6d8a2c85a7ddf38c0a9c512db64fcdf06))
 
 ## [1.22.3](https://github.com/react-native-async-storage/async-storage/compare/v1.22.2...v1.22.3) (2024-02-28)
 
-
 ### Bug Fixes
 
-* **android:** bridgeless mode broken on react-native 0.74 ([#1068](https://github.com/react-native-async-storage/async-storage/issues/1068)) ([253126d](https://github.com/react-native-async-storage/async-storage/commit/253126d08c9d26e407782995134231639b71bce5))
+- **android:** bridgeless mode broken on react-native 0.74 ([#1068](https://github.com/react-native-async-storage/async-storage/issues/1068)) ([253126d](https://github.com/react-native-async-storage/async-storage/commit/253126d08c9d26e407782995134231639b71bce5))
 
 ## [1.22.2](https://github.com/react-native-async-storage/async-storage/compare/v1.22.1...v1.22.2) (2024-02-23)
 
-
 ### Bug Fixes
 
-* **ios:** check directory before call delete ([#1066](https://github.com/react-native-async-storage/async-storage/issues/1066)) ([9db07c8](https://github.com/react-native-async-storage/async-storage/commit/9db07c8d10d9cee1c0ef8038d2374d2c231a41dc))
+- **ios:** check directory before call delete ([#1066](https://github.com/react-native-async-storage/async-storage/issues/1066)) ([9db07c8](https://github.com/react-native-async-storage/async-storage/commit/9db07c8d10d9cee1c0ef8038d2374d2c231a41dc))
 
 ## [1.22.1](https://github.com/react-native-async-storage/async-storage/compare/v1.22.0...v1.22.1) (2024-02-20)
 
-
 ### Bug Fixes
 
-* **ios:** Merging empty object should not override current value ([#1064](https://github.com/react-native-async-storage/async-storage/issues/1064)) ([ea9fc7a](https://github.com/react-native-async-storage/async-storage/commit/ea9fc7a38bf19c2aa8746a20bc9992f06943a753))
+- **ios:** Merging empty object should not override current value ([#1064](https://github.com/react-native-async-storage/async-storage/issues/1064)) ([ea9fc7a](https://github.com/react-native-async-storage/async-storage/commit/ea9fc7a38bf19c2aa8746a20bc9992f06943a753))
 
 # [1.22.0](https://github.com/react-native-async-storage/async-storage/compare/v1.21.0...v1.22.0) (2024-02-15)
 
-
 ### Features
 
-* add visionOS support ([#1063](https://github.com/react-native-async-storage/async-storage/issues/1063)) ([a170bac](https://github.com/react-native-async-storage/async-storage/commit/a170baced0265e197dc7c6659ee963efbc0418a6))
+- add visionOS support ([#1063](https://github.com/react-native-async-storage/async-storage/issues/1063)) ([a170bac](https://github.com/react-native-async-storage/async-storage/commit/a170baced0265e197dc7c6659ee963efbc0418a6))
 
 # [1.21.0](https://github.com/react-native-async-storage/async-storage/compare/v1.20.0...v1.21.0) (2023-11-29)
 
-
 ### Bug Fixes
 
-* missing `kotlinVersion` property ([#1042](https://github.com/react-native-async-storage/async-storage/issues/1042)) ([cff03e8](https://github.com/react-native-async-storage/async-storage/commit/cff03e8fa76e268002017e18349a0b462547df87))
-
+- missing `kotlinVersion` property ([#1042](https://github.com/react-native-async-storage/async-storage/issues/1042)) ([cff03e8](https://github.com/react-native-async-storage/async-storage/commit/cff03e8fa76e268002017e18349a0b462547df87))
 
 ### Features
 
-* **windows:** bump minimum target platform version to 10.0.17763.0 ([#1031](https://github.com/react-native-async-storage/async-storage/issues/1031)) ([5682e8c](https://github.com/react-native-async-storage/async-storage/commit/5682e8ce2548ff423d978b0317e1b70de7a8a76f))
+- **windows:** bump minimum target platform version to 10.0.17763.0 ([#1031](https://github.com/react-native-async-storage/async-storage/issues/1031)) ([5682e8c](https://github.com/react-native-async-storage/async-storage/commit/5682e8ce2548ff423d978b0317e1b70de7a8a76f))
 
 # [1.20.0](https://github.com/react-native-async-storage/async-storage/compare/v1.19.8...v1.20.0) (2023-11-28)
 
-
 ### Features
 
-* **android:** Bump versions for Next storage ([#1028](https://github.com/react-native-async-storage/async-storage/issues/1028)) ([14489a7](https://github.com/react-native-async-storage/async-storage/commit/14489a79fbb3d6fc31171e82a826cb4df6317cb8))
+- **android:** Bump versions for Next storage ([#1028](https://github.com/react-native-async-storage/async-storage/issues/1028)) ([14489a7](https://github.com/react-native-async-storage/async-storage/commit/14489a79fbb3d6fc31171e82a826cb4df6317cb8))
 
 ## [1.19.8](https://github.com/react-native-async-storage/async-storage/compare/v1.19.7...v1.19.8) (2023-11-22)
 
-
 ### Bug Fixes
 
-* add missing `README.md` (merge) ([#1032](https://github.com/react-native-async-storage/async-storage/issues/1032)) ([f974728](https://github.com/react-native-async-storage/async-storage/commit/f974728b7bee9911a32eaa0b8215c7c894436ea5))
+- add missing `README.md` (merge) ([#1032](https://github.com/react-native-async-storage/async-storage/issues/1032)) ([f974728](https://github.com/react-native-async-storage/async-storage/commit/f974728b7bee9911a32eaa0b8215c7c894436ea5))
 
 ## [1.19.7](https://github.com/react-native-async-storage/async-storage/compare/v1.19.6...v1.19.7) (2023-11-22)
 
-
 ### Bug Fixes
 
-* add missing `README.md` ([#1030](https://github.com/react-native-async-storage/async-storage/issues/1030)) ([821eb01](https://github.com/react-native-async-storage/async-storage/commit/821eb01b1a7326db592e80018246cdc662c6dc5d))
+- add missing `README.md` ([#1030](https://github.com/react-native-async-storage/async-storage/issues/1030)) ([821eb01](https://github.com/react-native-async-storage/async-storage/commit/821eb01b1a7326db592e80018246cdc662c6dc5d))
 
 ## [1.19.6](https://github.com/react-native-async-storage/async-storage/compare/v1.19.5...v1.19.6) (2023-11-21)
 
-
 ### Bug Fixes
 
-* widen supported version range ([#1029](https://github.com/react-native-async-storage/async-storage/issues/1029)) ([921f24a](https://github.com/react-native-async-storage/async-storage/commit/921f24a82597af6e88d5be7ccf2cceccc70da554))
+- widen supported version range ([#1029](https://github.com/react-native-async-storage/async-storage/issues/1029)) ([921f24a](https://github.com/react-native-async-storage/async-storage/commit/921f24a82597af6e88d5be7ccf2cceccc70da554))
 
 ## [1.19.5](https://github.com/react-native-async-storage/async-storage/compare/v1.19.4...v1.19.5) (2023-11-10)
 
-
 ### Bug Fixes
 
-* **android:** add buildFeaturesbuildConfig for android gradle plugin 8 ([#1026](https://github.com/react-native-async-storage/async-storage/issues/1026)) ([f54a93b](https://github.com/react-native-async-storage/async-storage/commit/f54a93b55a6fdafdf3a820e7d625469ba7a1bec3))
+- **android:** add buildFeaturesbuildConfig for android gradle plugin 8 ([#1026](https://github.com/react-native-async-storage/async-storage/issues/1026)) ([f54a93b](https://github.com/react-native-async-storage/async-storage/commit/f54a93b55a6fdafdf3a820e7d625469ba7a1bec3))
 
 ## [1.19.4](https://github.com/react-native-async-storage/async-storage/compare/v1.19.3...v1.19.4) (2023-11-01)
 
-
 ### Bug Fixes
 
-* **tvos:** Apple TV warning should only happen once ([#1021](https://github.com/react-native-async-storage/async-storage/issues/1021)) ([c770d4d](https://github.com/react-native-async-storage/async-storage/commit/c770d4d9e15cf56f653bf85c2c8916df272b90e5))
+- **tvos:** Apple TV warning should only happen once ([#1021](https://github.com/react-native-async-storage/async-storage/issues/1021)) ([c770d4d](https://github.com/react-native-async-storage/async-storage/commit/c770d4d9e15cf56f653bf85c2c8916df272b90e5))
 
 ## [1.19.3](https://github.com/react-native-async-storage/async-storage/compare/v1.19.2...v1.19.3) (2023-08-24)
 
-
 ### Bug Fixes
 
-* **ios:** fix `pod install` on RN 0.70.x + New Arch ([#1004](https://github.com/react-native-async-storage/async-storage/issues/1004)) ([e15432c](https://github.com/react-native-async-storage/async-storage/commit/e15432cea0b8691890a4cf08d69639ad31f09421)), closes [#997](https://github.com/react-native-async-storage/async-storage/issues/997)
+- **ios:** fix `pod install` on RN 0.70.x + New Arch ([#1004](https://github.com/react-native-async-storage/async-storage/issues/1004)) ([e15432c](https://github.com/react-native-async-storage/async-storage/commit/e15432cea0b8691890a4cf08d69639ad31f09421)), closes [#997](https://github.com/react-native-async-storage/async-storage/issues/997)
 
 ## [1.19.2](https://github.com/react-native-async-storage/async-storage/compare/v1.19.1...v1.19.2) (2023-08-13)
 
-
 ### Bug Fixes
 
-* tell users about how autolinking works ([#1000](https://github.com/react-native-async-storage/async-storage/issues/1000)) ([dc2155a](https://github.com/react-native-async-storage/async-storage/commit/dc2155a01088959bd52711a2a41e2296f5f58ebc))
+- tell users about how autolinking works ([#1000](https://github.com/react-native-async-storage/async-storage/issues/1000)) ([dc2155a](https://github.com/react-native-async-storage/async-storage/commit/dc2155a01088959bd52711a2a41e2296f5f58ebc))
 
 ## [1.19.1](https://github.com/react-native-async-storage/async-storage/compare/v1.19.0...v1.19.1) (2023-07-19)
 
-
 ### Bug Fixes
 
-* **android:** add required namespace in `build.gradle` ([#991](https://github.com/react-native-async-storage/async-storage/issues/991)) ([ce19249](https://github.com/react-native-async-storage/async-storage/commit/ce19249ca5c2a9ea41464bb430f476b78d3223b4))
+- **android:** add required namespace in `build.gradle` ([#991](https://github.com/react-native-async-storage/async-storage/issues/991)) ([ce19249](https://github.com/react-native-async-storage/async-storage/commit/ce19249ca5c2a9ea41464bb430f476b78d3223b4))
 
 # [1.19.0](https://github.com/react-native-async-storage/async-storage/compare/v1.18.2...v1.19.0) (2023-07-03)
 
-
 ### Features
 
-* add TurboModule support ([#910](https://github.com/react-native-async-storage/async-storage/issues/910)) ([86a7e90](https://github.com/react-native-async-storage/async-storage/commit/86a7e9021c99d5f96c5a67ae7b4692f48874c240))
+- add TurboModule support ([#910](https://github.com/react-native-async-storage/async-storage/issues/910)) ([86a7e90](https://github.com/react-native-async-storage/async-storage/commit/86a7e9021c99d5f96c5a67ae7b4692f48874c240))
 
 ## [1.18.2](https://github.com/react-native-async-storage/async-storage/compare/v1.18.1...v1.18.2) (2023-06-06)
 
-
 ### Bug Fixes
 
-* allow consumption of `RCTAsyncStorage` as TurboModule ([#965](https://github.com/react-native-async-storage/async-storage/issues/965)) ([62732d9](https://github.com/react-native-async-storage/async-storage/commit/62732d900f6dd2cc5b4c14230f33ed32114d6a09))
+- allow consumption of `RCTAsyncStorage` as TurboModule ([#965](https://github.com/react-native-async-storage/async-storage/issues/965)) ([62732d9](https://github.com/react-native-async-storage/async-storage/commit/62732d900f6dd2cc5b4c14230f33ed32114d6a09))
 
 ## [1.18.1](https://github.com/react-native-async-storage/async-storage/compare/v1.18.0...v1.18.1) (2023-03-29)
 
-
 ### Bug Fixes
 
-* declare support for react-native 0.72 ([#950](https://github.com/react-native-async-storage/async-storage/issues/950)) ([f15c419](https://github.com/react-native-async-storage/async-storage/commit/f15c419c7082ac191a1c7fedb79261c03a1c0584))
+- declare support for react-native 0.72 ([#950](https://github.com/react-native-async-storage/async-storage/issues/950)) ([f15c419](https://github.com/react-native-async-storage/async-storage/commit/f15c419c7082ac191a1c7fedb79261c03a1c0584))
 
 # [1.18.0](https://github.com/react-native-async-storage/async-storage/compare/v1.17.12...v1.18.0) (2023-03-27)
 
-
 ### Features
 
-* **android:** Bump Next version dependencies, min and target SDK ([#949](https://github.com/react-native-async-storage/async-storage/issues/949)) ([271a040](https://github.com/react-native-async-storage/async-storage/commit/271a0400db12b50945882e062260826a393f1a3d))
+- **android:** Bump Next version dependencies, min and target SDK ([#949](https://github.com/react-native-async-storage/async-storage/issues/949)) ([271a040](https://github.com/react-native-async-storage/async-storage/commit/271a0400db12b50945882e062260826a393f1a3d))
 
 ## [1.17.12](https://github.com/react-native-async-storage/async-storage/compare/v1.17.11...v1.17.12) (2023-03-15)
 
-
 ### Bug Fixes
 
-* **deploy:** auth bot as git user ([#938](https://github.com/react-native-async-storage/async-storage/issues/938)) ([4de4baa](https://github.com/react-native-async-storage/async-storage/commit/4de4baa858ca707ff9d7584a1c1c0d45396a60ec))
-* **deploy:** GH token naming ([#939](https://github.com/react-native-async-storage/async-storage/issues/939)) ([06ef84c](https://github.com/react-native-async-storage/async-storage/commit/06ef84c3d03560af9654527c11dbc28392ca7562))
+- **deploy:** auth bot as git user ([#938](https://github.com/react-native-async-storage/async-storage/issues/938)) ([4de4baa](https://github.com/react-native-async-storage/async-storage/commit/4de4baa858ca707ff9d7584a1c1c0d45396a60ec))
+- **deploy:** GH token naming ([#939](https://github.com/react-native-async-storage/async-storage/issues/939)) ([06ef84c](https://github.com/react-native-async-storage/async-storage/commit/06ef84c3d03560af9654527c11dbc28392ca7562))
 
 ## [1.17.11](https://github.com/react-native-async-storage/async-storage/compare/v1.17.10...v1.17.11) (2022-11-11)
 
-
 ### Bug Fixes
 
-* declare support for react-native 0.71 ([#870](https://github.com/react-native-async-storage/async-storage/issues/870)) ([1bf1a98](https://github.com/react-native-async-storage/async-storage/commit/1bf1a98ce7085787e8a7106fafa5a2b35f408561))
+- declare support for react-native 0.71 ([#870](https://github.com/react-native-async-storage/async-storage/issues/870)) ([1bf1a98](https://github.com/react-native-async-storage/async-storage/commit/1bf1a98ce7085787e8a7106fafa5a2b35f408561))
 
 ## [1.17.10](https://github.com/react-native-async-storage/async-storage/compare/v1.17.9...v1.17.10) (2022-08-24)
 
-
 ### Bug Fixes
 
-* declare support for react-native 0.70 ([#836](https://github.com/react-native-async-storage/async-storage/issues/836)) ([7c2eb06](https://github.com/react-native-async-storage/async-storage/commit/7c2eb060388b31a210f6b148e71cee9825715f1e))
+- declare support for react-native 0.70 ([#836](https://github.com/react-native-async-storage/async-storage/issues/836)) ([7c2eb06](https://github.com/react-native-async-storage/async-storage/commit/7c2eb060388b31a210f6b148e71cee9825715f1e))
 
 ## [1.17.9](https://github.com/react-native-async-storage/async-storage/compare/v1.17.8...v1.17.9) (2022-08-12)
 
-
 ### Bug Fixes
 
-* re-export AsyncStorageStatic type ([#829](https://github.com/react-native-async-storage/async-storage/issues/829)) ([a29e4f3](https://github.com/react-native-async-storage/async-storage/commit/a29e4f368212e464fb11e9fa84fa47a183ef6b07))
+- re-export AsyncStorageStatic type ([#829](https://github.com/react-native-async-storage/async-storage/issues/829)) ([a29e4f3](https://github.com/react-native-async-storage/async-storage/commit/a29e4f368212e464fb11e9fa84fa47a183ef6b07))
 
 ## [1.17.8](https://github.com/react-native-async-storage/async-storage/compare/v1.17.7...v1.17.8) (2022-08-08)
 
-
 ### Bug Fixes
 
-* remove warning about `multiMerge` not being implemented ([#827](https://github.com/react-native-async-storage/async-storage/issues/827)) ([cc69173](https://github.com/react-native-async-storage/async-storage/commit/cc69173824be66d9c1251bdad2d9b48f33aa5594))
+- remove warning about `multiMerge` not being implemented ([#827](https://github.com/react-native-async-storage/async-storage/issues/827)) ([cc69173](https://github.com/react-native-async-storage/async-storage/commit/cc69173824be66d9c1251bdad2d9b48f33aa5594))
 
 ## [1.17.7](https://github.com/react-native-async-storage/async-storage/compare/v1.17.6...v1.17.7) (2022-06-23)
 
-
 ### Bug Fixes
 
-* declare support for react-native 0.69 ([#817](https://github.com/react-native-async-storage/async-storage/issues/817)) ([802ad19](https://github.com/react-native-async-storage/async-storage/commit/802ad1986125fdbd079acbf6cf5347b82142da36))
+- declare support for react-native 0.69 ([#817](https://github.com/react-native-async-storage/async-storage/issues/817)) ([802ad19](https://github.com/react-native-async-storage/async-storage/commit/802ad1986125fdbd079acbf6cf5347b82142da36))
 
 ## [1.17.6](https://github.com/react-native-async-storage/async-storage/compare/v1.17.5...v1.17.6) (2022-06-01)
 
-
 ### Bug Fixes
 
-* **windows:** change `WindowsTargetPlatformVersion` to 10.0 ([#810](https://github.com/react-native-async-storage/async-storage/issues/810)) ([668f384](https://github.com/react-native-async-storage/async-storage/commit/668f384963a7c1ea0be9df693af5806b552d998b))
+- **windows:** change `WindowsTargetPlatformVersion` to 10.0 ([#810](https://github.com/react-native-async-storage/async-storage/issues/810)) ([668f384](https://github.com/react-native-async-storage/async-storage/commit/668f384963a7c1ea0be9df693af5806b552d998b))
 
 ## [1.17.5](https://github.com/react-native-async-storage/async-storage/compare/v1.17.4...v1.17.5) (2022-05-18)
 
-
 ### Bug Fixes
 
-* invalid module name in augmentation ([#805](https://github.com/react-native-async-storage/async-storage/issues/805)) ([db28513](https://github.com/react-native-async-storage/async-storage/commit/db285138137b7d213598961b672be6ed8fade754))
+- invalid module name in augmentation ([#805](https://github.com/react-native-async-storage/async-storage/issues/805)) ([db28513](https://github.com/react-native-async-storage/async-storage/commit/db285138137b7d213598961b672be6ed8fade754))
 
 ## [1.17.4](https://github.com/react-native-async-storage/async-storage/compare/v1.17.3...v1.17.4) (2022-05-09)
 
-
 ### Bug Fixes
 
-* `multiGet` accepts read-only array ([#803](https://github.com/react-native-async-storage/async-storage/issues/803)) ([b044512](https://github.com/react-native-async-storage/async-storage/commit/b0445123bb8b315375ed4af3e97435cf8f870b39))
+- `multiGet` accepts read-only array ([#803](https://github.com/react-native-async-storage/async-storage/issues/803)) ([b044512](https://github.com/react-native-async-storage/async-storage/commit/b0445123bb8b315375ed4af3e97435cf8f870b39))
 
 ## [1.17.3](https://github.com/react-native-async-storage/async-storage/compare/v1.17.2...v1.17.3) (2022-03-31)
 
-
 ### Bug Fixes
 
-* declare support for react-native 0.68 ([#789](https://github.com/react-native-async-storage/async-storage/issues/789)) ([6e2c941](https://github.com/react-native-async-storage/async-storage/commit/6e2c941d51edb1c8d4d15b22787646b8b45e94ae))
+- declare support for react-native 0.68 ([#789](https://github.com/react-native-async-storage/async-storage/issues/789)) ([6e2c941](https://github.com/react-native-async-storage/async-storage/commit/6e2c941d51edb1c8d4d15b22787646b8b45e94ae))
 
 ## [1.17.2](https://github.com/react-native-async-storage/async-storage/compare/v1.17.1...v1.17.2) (2022-03-30)
 
-
 ### Bug Fixes
 
-* cannot find `react-native-test-app` when Metro starts ([#788](https://github.com/react-native-async-storage/async-storage/issues/788)) ([e222452](https://github.com/react-native-async-storage/async-storage/commit/e2224526c6a934c13ba5d04b7a5779ad0e083d37))
+- cannot find `react-native-test-app` when Metro starts ([#788](https://github.com/react-native-async-storage/async-storage/issues/788)) ([e222452](https://github.com/react-native-async-storage/async-storage/commit/e2224526c6a934c13ba5d04b7a5779ad0e083d37))
 
 ## [1.17.1](https://github.com/react-native-async-storage/async-storage/compare/v1.17.0...v1.17.1) (2022-03-29)
 
-
 ### Bug Fixes
 
-* `multiRemove` should accept `readonly string[]` ([#787](https://github.com/react-native-async-storage/async-storage/issues/787)) ([298bbb0](https://github.com/react-native-async-storage/async-storage/commit/298bbb00420bf789b69fa574a2884463ec950f5c))
+- `multiRemove` should accept `readonly string[]` ([#787](https://github.com/react-native-async-storage/async-storage/issues/787)) ([298bbb0](https://github.com/react-native-async-storage/async-storage/commit/298bbb00420bf789b69fa574a2884463ec950f5c))
 
 # [1.17.0](https://github.com/react-native-async-storage/async-storage/compare/v1.16.3...v1.17.0) (2022-03-18)
 
-
 ### Features
 
-* **android:** bump room to 2.4.2, allowing arm64 jdk compile ([#773](https://github.com/react-native-async-storage/async-storage/issues/773)) ([774fb78](https://github.com/react-native-async-storage/async-storage/commit/774fb7828219823195ee704099bbbd902ffc5d07))
+- **android:** bump room to 2.4.2, allowing arm64 jdk compile ([#773](https://github.com/react-native-async-storage/async-storage/issues/773)) ([774fb78](https://github.com/react-native-async-storage/async-storage/commit/774fb7828219823195ee704099bbbd902ffc5d07))
 
 ## [1.16.3](https://github.com/react-native-async-storage/async-storage/compare/v1.16.2...v1.16.3) (2022-03-16)
 
-
 ### Bug Fixes
 
-* **types:** wrong void return type of multiGet ([#767](https://github.com/react-native-async-storage/async-storage/issues/767)) ([6ba9d69](https://github.com/react-native-async-storage/async-storage/commit/6ba9d690560fa33d21a75358f7dae379a7f705f8))
+- **types:** wrong void return type of multiGet ([#767](https://github.com/react-native-async-storage/async-storage/issues/767)) ([6ba9d69](https://github.com/react-native-async-storage/async-storage/commit/6ba9d690560fa33d21a75358f7dae379a7f705f8))
 
 ## [1.16.2](https://github.com/react-native-async-storage/async-storage/compare/v1.16.1...v1.16.2) (2022-03-15)
 
-
 ### Bug Fixes
 
-* **windows:** fix MultiRemove by using CHECK_SQL_OK macro ([#772](https://github.com/react-native-async-storage/async-storage/issues/772)) ([6f3f3ba](https://github.com/react-native-async-storage/async-storage/commit/6f3f3ba2d3192c8809d7a1f4c0e629f46818c63b))
+- **windows:** fix MultiRemove by using CHECK_SQL_OK macro ([#772](https://github.com/react-native-async-storage/async-storage/issues/772)) ([6f3f3ba](https://github.com/react-native-async-storage/async-storage/commit/6f3f3ba2d3192c8809d7a1f4c0e629f46818c63b))
 
 ## [1.16.1](https://github.com/react-native-async-storage/async-storage/compare/v1.16.0...v1.16.1) (2022-02-10)
 
-
 ### Bug Fixes
 
-* also publish source map files ([#748](https://github.com/react-native-async-storage/async-storage/issues/748)) ([199a2c2](https://github.com/react-native-async-storage/async-storage/commit/199a2c2e6607b2b9af571aa2f3f9cc3057cf2af4))
+- also publish source map files ([#748](https://github.com/react-native-async-storage/async-storage/issues/748)) ([199a2c2](https://github.com/react-native-async-storage/async-storage/commit/199a2c2e6607b2b9af571aa2f3f9cc3057cf2af4))
 
 # [1.16.0](https://github.com/react-native-async-storage/async-storage/compare/v1.15.17...v1.16.0) (2022-02-09)
 
-
 ### Features
 
-* migrate from Flow to TypeScript ([#727](https://github.com/react-native-async-storage/async-storage/issues/727)) ([e3d36f3](https://github.com/react-native-async-storage/async-storage/commit/e3d36f313852c50884fefb12fcd341d37a16973f))
+- migrate from Flow to TypeScript ([#727](https://github.com/react-native-async-storage/async-storage/issues/727)) ([e3d36f3](https://github.com/react-native-async-storage/async-storage/commit/e3d36f313852c50884fefb12fcd341d37a16973f))
 
 ## [1.15.17](https://github.com/react-native-async-storage/async-storage/compare/v1.15.16...v1.15.17) (2022-01-24)
 
-
 ### Bug Fixes
 
-* **types:** remove 'this' binding expectations on hook fn types ([#736](https://github.com/react-native-async-storage/async-storage/issues/736)) ([cf76a4e](https://github.com/react-native-async-storage/async-storage/commit/cf76a4e820d5123a947face49a2c6757a6b2f681))
+- **types:** remove 'this' binding expectations on hook fn types ([#736](https://github.com/react-native-async-storage/async-storage/issues/736)) ([cf76a4e](https://github.com/react-native-async-storage/async-storage/commit/cf76a4e820d5123a947face49a2c6757a6b2f681))
 
 ## [1.15.16](https://github.com/react-native-async-storage/async-storage/compare/v1.15.15...v1.15.16) (2022-01-21)
 
-
 ### Bug Fixes
 
-* declare support for RN 0.67 ([#741](https://github.com/react-native-async-storage/async-storage/issues/741)) ([c14ea98](https://github.com/react-native-async-storage/async-storage/commit/c14ea987fd8b264ca4b09adc2f6fd765dd198eb3))
+- declare support for RN 0.67 ([#741](https://github.com/react-native-async-storage/async-storage/issues/741)) ([c14ea98](https://github.com/react-native-async-storage/async-storage/commit/c14ea987fd8b264ca4b09adc2f6fd765dd198eb3))
 
 ## [1.15.15](https://github.com/react-native-async-storage/async-storage/compare/v1.15.14...v1.15.15) (2022-01-11)
 
-
 ### Bug Fixes
 
-* align mock of multiMerge with actual behavior ([#733](https://github.com/react-native-async-storage/async-storage/issues/733)) ([2dee293](https://github.com/react-native-async-storage/async-storage/commit/2dee2935ede75d01f632e0f9b56a7105b7fd492f))
+- align mock of multiMerge with actual behavior ([#733](https://github.com/react-native-async-storage/async-storage/issues/733)) ([2dee293](https://github.com/react-native-async-storage/async-storage/commit/2dee2935ede75d01f632e0f9b56a7105b7fd492f))
 
 ## [1.15.14](https://github.com/react-native-async-storage/async-storage/compare/v1.15.13...v1.15.14) (2021-11-30)
 
-
 ### Bug Fixes
 
-* **windows:** fix crash when running windows module ([#719](https://github.com/react-native-async-storage/async-storage/issues/719)) ([309e252](https://github.com/react-native-async-storage/async-storage/commit/309e2529556a30b2eed992b4970863219a539d50))
+- **windows:** fix crash when running windows module ([#719](https://github.com/react-native-async-storage/async-storage/issues/719)) ([309e252](https://github.com/react-native-async-storage/async-storage/commit/309e2529556a30b2eed992b4970863219a539d50))
 
 ## [1.15.13](https://github.com/react-native-async-storage/async-storage/compare/v1.15.12...v1.15.13) (2021-11-24)
 
-
 ### Bug Fixes
 
-* wrong method referenced in validated input warning ([#715](https://github.com/react-native-async-storage/async-storage/issues/715)) ([a3e9537](https://github.com/react-native-async-storage/async-storage/commit/a3e9537e775147420bc3fcdc26b21efcfb6fada1))
+- wrong method referenced in validated input warning ([#715](https://github.com/react-native-async-storage/async-storage/issues/715)) ([a3e9537](https://github.com/react-native-async-storage/async-storage/commit/a3e9537e775147420bc3fcdc26b21efcfb6fada1))
 
 ## [1.15.12](https://github.com/react-native-async-storage/async-storage/compare/v1.15.11...v1.15.12) (2021-11-24)
 
-
 ### Bug Fixes
 
-* add type definition for jest mock ([#708](https://github.com/react-native-async-storage/async-storage/issues/708)) ([5f6d6a0](https://github.com/react-native-async-storage/async-storage/commit/5f6d6a045fcaa1a5b56a34ebad6d948e5530f965))
+- add type definition for jest mock ([#708](https://github.com/react-native-async-storage/async-storage/issues/708)) ([5f6d6a0](https://github.com/react-native-async-storage/async-storage/commit/5f6d6a045fcaa1a5b56a34ebad6d948e5530f965))

--- a/yarn.lock
+++ b/yarn.lock
@@ -2298,17 +2298,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@changesets/changelog-github@npm:^0.5.0":
-  version: 0.5.0
-  resolution: "@changesets/changelog-github@npm:0.5.0"
-  dependencies:
-    "@changesets/get-github-info": "npm:^0.6.0"
-    "@changesets/types": "npm:^6.0.0"
-    dotenv: "npm:^8.1.0"
-  checksum: 10c0/fc6a6947185af6f1c7543c572ca6e46d733188586ab873c75476f389fb11c675df1c230a56394d490aa9a7f13bdf88d23541265deeda77f167d06b0cc3206923
-  languageName: node
-  linkType: hard
-
 "@changesets/cli@npm:^2.27.7":
   version: 2.27.7
   resolution: "@changesets/cli@npm:2.27.7"
@@ -2385,16 +2374,6 @@ __metadata:
     fs-extra: "npm:^7.0.1"
     semver: "npm:^7.5.3"
   checksum: 10c0/037a038a300062f4764708696996c0847fc9c71b3ab88ee779d2925942efa2a61967a266b87b9ea58ea5a5d9a728ca47e63f81a3e749eb16b7195644b21bca17
-  languageName: node
-  linkType: hard
-
-"@changesets/get-github-info@npm:^0.6.0":
-  version: 0.6.0
-  resolution: "@changesets/get-github-info@npm:0.6.0"
-  dependencies:
-    dataloader: "npm:^1.4.0"
-    node-fetch: "npm:^2.5.0"
-  checksum: 10c0/21fde8a8cb48091a8ea8be37defbc0dca5defe10a097025968b273076657f354032803a5db31ffe0fa86ab089383faa981ab674489d31e38bf7bc4dcf981ad79
   languageName: node
   linkType: hard
 
@@ -4281,7 +4260,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@react-native-async-storage/root@workspace:."
   dependencies:
-    "@changesets/changelog-github": "npm:^0.5.0"
     "@changesets/cli": "npm:^2.27.7"
     concurrently: "npm:^8.2.2"
     eslint: "npm:^8.54.0"
@@ -9708,13 +9686,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dataloader@npm:^1.4.0":
-  version: 1.4.0
-  resolution: "dataloader@npm:1.4.0"
-  checksum: 10c0/5fa4c843b9e60195092f1fc7e2acaff318ed46886dc670ddff683bc560f12d4079e6d1e77749501b7e111a8582d26a2aa2a2fbe6d7d5e1520cef64f4e1fd242d
-  languageName: node
-  linkType: hard
-
 "date-fns@npm:^2.30.0":
   version: 2.30.0
   resolution: "date-fns@npm:2.30.0"
@@ -10334,13 +10305,6 @@ __metadata:
   version: 16.3.1
   resolution: "dotenv@npm:16.3.1"
   checksum: 10c0/b95ff1bbe624ead85a3cd70dbd827e8e06d5f05f716f2d0cbc476532d54c7c9469c3bc4dd93ea519f6ad711cb522c00ac9a62b6eb340d5affae8008facc3fbd7
-  languageName: node
-  linkType: hard
-
-"dotenv@npm:^8.1.0":
-  version: 8.6.0
-  resolution: "dotenv@npm:8.6.0"
-  checksum: 10c0/6750431dea8efbd54b9f2d9681b04e1ccc7989486461dcf058bb708d9e3d63b04115fcdf8840e38ad1e24a4a2e1e7c1560626c5e3ac7bc09371b127c49e2d45f
   languageName: node
   linkType: hard
 
@@ -16870,7 +16834,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-fetch@npm:^2.2.0, node-fetch@npm:^2.5.0, node-fetch@npm:^2.6.0, node-fetch@npm:^2.6.1, node-fetch@npm:^2.6.11, node-fetch@npm:^2.6.12, node-fetch@npm:^2.6.7":
+"node-fetch@npm:^2.2.0, node-fetch@npm:^2.6.0, node-fetch@npm:^2.6.1, node-fetch@npm:^2.6.11, node-fetch@npm:^2.6.12, node-fetch@npm:^2.6.7":
   version: 2.7.0
   resolution: "node-fetch@npm:2.7.0"
   dependencies:


### PR DESCRIPTION
## Summary

Couple of things:
- I still have no idea why GH action is picking gh bot as git credentials (it works fine in a fork), so I'm using variables now for name and email for the bot
- I've noticed during my tests that README would be mixed up by changeset, so I applied changes
- Also I've noticed that one of our releases has not been pushed to npm, so added a warning for it in README
- I've added `api` and `sqlite-storage` to ignore, to avoid changesets releasing it for now (not ready yet)
