### PR TITLE
fix: do not persist credentials for release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: "false"
       - name: Setup project
         uses: ./.github/actions/setup-project
       - name: Install dependencies


### PR DESCRIPTION
## Summary

I hope this is the last follow up 😄 Turns out, even if we set git credentials during job run, the `checkout` step had set git credentials upfront, which took precedence over ours. Because of that, github-bot was used to create a branch, not @AsyncStorageBot . 