### PR TITLE
fix(android): replace `onCatalystInstanceDestroy` with `invalidate`

### DIFF
--- a/.changeset/quiet-snakes-count.md
+++ b/.changeset/quiet-snakes-count.md
@@ -1,0 +1,5 @@
+---
+"@react-native-async-storage/async-storage": major
+---
+
+Support 0.74 (by migrating off deprecated `onCatalystInstanceDestroy`) — unfortunately, this also means that we must bump the minimum supported version to 0.65

--- a/packages/default-storage/package.json
+++ b/packages/default-storage/package.json
@@ -66,7 +66,7 @@
     "merge-options": "^3.0.4"
   },
   "peerDependencies": {
-    "react-native": "^0.0.0-0 || >=0.60 <1.0"
+    "react-native": "^0.0.0-0 || >=0.65 <1.0"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4238,7 +4238,7 @@ __metadata:
     typescript: "npm:^5.3.0"
     webdriverio: "npm:^8.24.0"
   peerDependencies:
-    react-native: ^0.0.0-0 || >=0.60 <1.0
+    react-native: ^0.0.0-0 || >=0.65 <1.0
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Summary

`onCatalystInstanceDestroy` was removed in 0.74, replaced by `invalidate`.

However, `invalidate` was introduced in 0.65: https://github.com/facebook/react-native/commit/18c8417290823e67e211bde241ae9dde27b72f17#diff-736ae7997f3da9751f0f5cf756d8ce4401190bda205c894acc77efe959bd1ecb

And our `package.json` says we still support 0.60: https://github.com/react-native-async-storage/async-storage/blob/fbd4ccf78b9a75d2231935321f7ae0c67811ff0a/packages/default-storage/package.json#L69

In order to make this change, we will also need to bump the minimum version to 0.65. This means we will have to make a major release.

Resolves #1106.

## Test Plan

CI should pass.