### PR TITLE
Fixes the output example code multiMerge

### DIFF
--- a/packages/website/docs/API.md
+++ b/packages/website/docs/API.md
@@ -379,13 +379,13 @@ const multiMerge = [
 
 
 mergeMultiple = async () => {
-  let currentlyMerged
+  let parsedCurrentlyMerged
 
   try {
     await AsyncStorage.multiSet(multiSet)
     await AsyncStorage.multiMerge(multiMerge)
-    currentlyMerged = await AsyncStorage.multiGet(['@MyApp_USER_1', '@MyApp_USER_2'])
-    const parsedCurrentlyMerged = currentlyMerged.map(([key, value]) => [
+    const currentlyMerged = await AsyncStorage.multiGet(['@MyApp_USER_1', '@MyApp_USER_2'])
+    parsedCurrentlyMerged = currentlyMerged.map(([key, value]) => [
       key,
       JSON.parse(value),
     ]);

--- a/packages/website/docs/API.md
+++ b/packages/website/docs/API.md
@@ -385,35 +385,44 @@ mergeMultiple = async () => {
     await AsyncStorage.multiSet(multiSet)
     await AsyncStorage.multiMerge(multiMerge)
     currentlyMerged = await AsyncStorage.multiGet(['@MyApp_USER_1', '@MyApp_USER_2'])
+    const parsedCurrentlyMerged = currentlyMerged.map(([key, value]) => [
+      key,
+      JSON.parse(value),
+    ]);
   } catch(e) {
     // error
   }
 
-  console.log(currentlyMerged)
+  console.log(
+    'parsedCurrentlyMerged',
+    JSON.stringify(parsedCurrentlyMerged, null, 2),
+  );
   // console.log output:
-  // [
-  //   [
-  //     'USER_1',
-  //     {
-  //       name:"Tom",
-  //       age:30,
-  //       traits: {
-  //         hair: 'brown'
-  //         eyes: 'blue'
-  //       }
-  //     }
-  //   ],
-  //   [
-  //     'USER_2',
-  //     {
-  //       name:'Sarah',
-  //       age:26,
-  //       traits: {
-  //         hair: 'green'
-  //       }
-  //     }
-  //   ]
-  // ]
+  /* 
+  [
+    [
+      "@MyApp_USER_1",
+      {
+        "name": "Tom",
+        "age": 31,
+        "traits": {
+          "hair": "brown",
+          "eyes": "blue"
+        }
+      }
+    ],
+    [
+      "@MyApp_USER_2",
+      {
+        "name": "Sarah",
+        "age": 26,
+        "traits": {
+          "hair": "green"
+        }
+      }
+    ]
+  ]
+  */
 }
 ```
 


### PR DESCRIPTION
Fixes the output example code in the multiMerge API documentation.

## Summary

This PR fixes the incorrect code output example for multiMerge.
Link Issue: https://github.com/react-native-async-storage/async-storage/issues/1137

## Test Plan

Run sample code
