### PR TITLE
chore(apple): fix build issues discovered internally

### DIFF
--- a/.changeset/modern-bugs-battle.md
+++ b/.changeset/modern-bugs-battle.md
@@ -1,0 +1,5 @@
+---
+"@react-native-async-storage/async-storage": patch
+---
+
+Mark some methods as nonnull

--- a/packages/default-storage/ios/RNCAsyncStorage.h
+++ b/packages/default-storage/ios/RNCAsyncStorage.h
@@ -27,6 +27,9 @@
  *
  * Keys and values must always be strings or an error is returned.
  */
+
+NS_ASSUME_NONNULL_BEGIN
+
 @interface RNCAsyncStorage : NSObject <
 #ifdef RCT_NEW_ARCH_ENABLED
                                  NativeAsyncStorageModuleSpec
@@ -50,13 +53,15 @@
 
 // Grab data from the cache. ResponseBlock result array will have an error at position 0, and an
 // array of arrays at position 1.
-- (void)multiGet:(NSArray<NSString *> *_Nullable)keys callback:(RCTResponseSenderBlock _Nullable )callback;
+- (void)multiGet:(NSArray<NSString *> *)keys callback:(RCTResponseSenderBlock)callback;
 
 // Add multiple key value pairs to the cache.
-- (void)multiSet:(NSArray<NSArray<NSString *> *> *_Nullable)kvPairs
-        callback:(RCTResponseSenderBlock _Nullable )callback;
+- (void)multiSet:(NSArray<NSArray<NSString *> *> *)kvPairs
+        callback:(RCTResponseSenderBlock)callback;
 
 // Interface for natively fetching all the keys from the storage data.
-- (void)getAllKeys:(RCTResponseSenderBlock _Nullable )callback;
+- (void)getAllKeys:(RCTResponseSenderBlock )callback;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/packages/default-storage/ios/RNCAsyncStorage.h
+++ b/packages/default-storage/ios/RNCAsyncStorage.h
@@ -50,13 +50,13 @@
 
 // Grab data from the cache. ResponseBlock result array will have an error at position 0, and an
 // array of arrays at position 1.
-- (void)multiGet:(NSArray<NSString *> *)keys callback:(RCTResponseSenderBlock)callback;
+- (void)multiGet:(NSArray<NSString *> *_Nullable)keys callback:(RCTResponseSenderBlock _Nullable )callback;
 
 // Add multiple key value pairs to the cache.
-- (void)multiSet:(NSArray<NSArray<NSString *> *> *)kvPairs
-        callback:(RCTResponseSenderBlock)callback;
+- (void)multiSet:(NSArray<NSArray<NSString *> *> *_Nullable)kvPairs
+        callback:(RCTResponseSenderBlock _Nullable )callback;
 
 // Interface for natively fetching all the keys from the storage data.
-- (void)getAllKeys:(RCTResponseSenderBlock)callback;
+- (void)getAllKeys:(RCTResponseSenderBlock _Nullable )callback;
 
 @end

--- a/packages/default-storage/ios/RNCAsyncStorage.mm
+++ b/packages/default-storage/ios/RNCAsyncStorage.mm
@@ -302,7 +302,7 @@ static void RCTStorageDirectoryMigrate(NSString *oldDirectoryPath,
         // this folder and attempt folder copying again
         if (error != nil && error.code == 4 &&
             [newDirectoryPath isEqualToString:RCTGetStorageDirectory()]) {
-            NSError *error = nil;
+            error = nil;
             _createStorageDirectory(RCTCreateStorageDirectoryPath(@""), &error);
             if (error == nil) {
                 RCTStorageDirectoryMigrate(
@@ -559,7 +559,7 @@ RCT_EXPORT_MODULE()
     return nil;
 }
 
-- (NSDictionary *)_writeManifest:(NSMutableArray<NSDictionary *> **)errors
+- (NSDictionary *)_writeManifest:(NSMutableArray<NSDictionary *> *__autoreleasing *)errors
 {
     NSError *error;
     NSString *serialized = RCTJSONStringify(_manifest, &error);
@@ -587,7 +587,7 @@ RCT_EXPORT_MODULE()
     return errorOut;
 }
 
-- (NSString *)_getValueForKey:(NSString *)key errorOut:(NSDictionary **)errorOut
+- (NSString *)_getValueForKey:(NSString *)key errorOut:(NSDictionary *__autoreleasing *)errorOut
 {
     NSString *value =
         _manifest[key];  // nil means missing, null means there may be a data file, else: NSString
@@ -699,14 +699,14 @@ RCT_EXPORT_METHOD(multiGet:(NSArray<NSString *> *)keys
         }
     }
 
-    NSDictionary *errorOut = [self _ensureSetup];
-    if (errorOut) {
-        callback(@[@[errorOut], (id)kCFNull]);
+    NSDictionary *ensureSetupErrorOut = [self _ensureSetup];
+    if (ensureSetupErrorOut) {
+        callback(@[@[ensureSetupErrorOut], (id)kCFNull]);
         return;
     }
     [self _multiGet:keys
            callback:callback
-             getter:^(NSUInteger i, NSString *key, NSDictionary **errorOut) {
+             getter:^(__unused NSUInteger i, NSString *key, NSDictionary **errorOut) {
                return [self _getValueForKey:key errorOut:errorOut];
              }];
 }


### PR DESCRIPTION
## Summary

At my side of Microsoft, we have recently "vendored" a couple of libraries. Which means, we started building them from source using our own generated Xcode project (not the one cocoapods generates), which has much stricter build flags / treats warnings as errors. In doing so, I caught a couple of issues in React Native async-storage I'd like to push back up!

Namely:
- Fix warnings where we need to add a bunch of either `__nullable` or `__nonnull` specifiers. 
- Fix a "declaration of variable shadows another local variable" where we had two `NSError *error = nil` declarations in a row
- Fix another "declaration of variable shadows another local variable" with two NSError variables by renaming one of them
- Add an `__unused` clang tag to a parameter
- Add `__autoreleaseing` clang tags to two more parameters. 
  - The error internally without these was `Method parameter of type 'NSMutableArray<NSDictionary *> *__autoreleasing *' with no explicit ownership`, for the record. 

## Test Plan

CI should pass