### PR TITLE
fix(android): remove unnecessary `getViewManagers` overrides

### DIFF
--- a/.changeset/many-pianos-guess.md
+++ b/.changeset/many-pianos-guess.md
@@ -1,0 +1,5 @@
+---
+"@react-native-async-storage/async-storage": patch
+---
+
+Remove unnecessary `getViewManagers` overrides

--- a/packages/default-storage/android/src/javaPackage/java/com/reactnativecommunity/asyncstorage/AsyncStoragePackage.java
+++ b/packages/default-storage/android/src/javaPackage/java/com/reactnativecommunity/asyncstorage/AsyncStoragePackage.java
@@ -32,11 +32,6 @@ import javax.annotation.Nonnull;
 public class AsyncStoragePackage extends TurboReactPackage {
 
     @Override
-    protected List<ModuleSpec> getViewManagers(ReactApplicationContext reactContext) {
-        return null;
-    }
-
-    @Override
     public NativeModule getModule(String name, @Nonnull ReactApplicationContext reactContext) {
         switch (name) {
             case AsyncStorageModule.NAME:

--- a/packages/default-storage/android/src/kotlinPackage/java/com/reactnativecommunity/asyncstorage/AsyncStoragePackage.kt
+++ b/packages/default-storage/android/src/kotlinPackage/java/com/reactnativecommunity/asyncstorage/AsyncStoragePackage.kt
@@ -50,6 +50,4 @@ class AsyncStoragePackage : TurboReactPackage() {
             throw RuntimeException("No ReactModuleInfoProvider for AsyncStoragePackage$\$ReactModuleInfoProvider", e)
         }
     }
-
-    override fun getViewManagers(reactContext: ReactApplicationContext?): MutableList<ModuleSpec>? = null
 }

--- a/packages/default-storage/example/android/gradle.properties
+++ b/packages/default-storage/example/android/gradle.properties
@@ -25,9 +25,7 @@ org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=512m -XX:+HeapDumpOnOutOfMemoryEr
 # https://developer.android.com/topic/libraries/support-library/androidx-rn
 android.useAndroidX=true
 # Automatically convert third-party libraries to use AndroidX
-android.enableJetifier=true
-# Jetifier randomly fails on these libraries
-android.jetifier.ignorelist=hermes-android
+android.enableJetifier=false
 
 # Use this property to specify which architecture you want to build.
 # You can also override it from the CLI using


### PR DESCRIPTION
## Summary

The `getViewManagers` overrides aren't doing anything and React Native already provides default implementations. The signature has also been changed in 0.77, breaking builds.

Resolves #1180.

## Test Plan

n/a