### PR TITLE
[0.80] AsyncStorageModule should not implement ModuleDataCleaner.Cleanable

### DIFF
--- a/.changeset/curly-carrots-exist.md
+++ b/.changeset/curly-carrots-exist.md
@@ -1,0 +1,5 @@
+---
+"@react-native-async-storage/async-storage": minor
+---
+
+Fix support for React Native 0.80

--- a/packages/default-storage/android/src/main/java/com/reactnativecommunity/asyncstorage/AsyncStorageModule.java
+++ b/packages/default-storage/android/src/main/java/com/reactnativecommunity/asyncstorage/AsyncStorageModule.java
@@ -24,7 +24,6 @@ import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.common.ReactConstants;
 import com.facebook.react.common.annotations.VisibleForTesting;
 import com.facebook.react.module.annotations.ReactModule;
-import com.facebook.react.modules.common.ModuleDataCleaner;
 
 import java.util.ArrayDeque;
 import java.util.HashSet;
@@ -32,8 +31,7 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 
 @ReactModule(name = AsyncStorageModule.NAME)
-public final class AsyncStorageModule
-    extends NativeAsyncStorageModuleSpec implements ModuleDataCleaner.Cleanable {
+public final class AsyncStorageModule extends NativeAsyncStorageModuleSpec {
 
   // changed name to not conflict with AsyncStorage from RN repo
   public static final String NAME = "RNCAsyncStorage";
@@ -85,14 +83,6 @@ public final class AsyncStorageModule
     mShuttingDown = true;
     // ensure we close database when activity is destroyed
     mReactDatabaseSupplier.closeDatabase();
-  }
-
-  @Override
-  public void clearSensitiveData() {
-    // Clear local storage. If fails, crash, since the app is potentially in a bad state and could
-    // cause a privacy violation. We're still not recovering from this well, but at least the error
-    // will be reported to the server.
-    mReactDatabaseSupplier.clearAndCloseDatabase();
   }
 
   /**


### PR DESCRIPTION
## Summary

This interface is now `internal` inside React Native (starting from 0.80) and will be removed in a future version of React Native.

The methods `clearSensitiveData` was never called altogether so it's safe to remove.

## Test Plan

I guess I will rely on CI being green here