### PR TITLE
Add automatic JSON serialization to storage hook - Opus 4.5

### DIFF
--- a/packages/default-storage/jest.config.js
+++ b/packages/default-storage/jest.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  preset: "react-native",
+  testMatch: ["<rootDir>/src/__tests__/**/?(*.)+(spec|test).[t]s"],
+  modulePathIgnorePatterns: ["<rootDir>/lib/"],
+};

--- a/packages/default-storage/jest/async-storage-mock.d.ts
+++ b/packages/default-storage/jest/async-storage-mock.d.ts
@@ -1,9 +1,15 @@
 import type {
   AsyncStorageHook,
+  AsyncStorageObjectHook,
   AsyncStorageStatic,
 } from "../lib/typescript/types";
 
 export function useAsyncStorage(key: string): AsyncStorageHook;
+
+export function useAsyncStorageObject<T>(
+  key: string,
+  defaultValue?: T
+): AsyncStorageObjectHook<T>;
 
 declare const AsyncStorage: AsyncStorageStatic;
 export default AsyncStorage;

--- a/packages/default-storage/jest/async-storage-mock.js
+++ b/packages/default-storage/jest/async-storage-mock.js
@@ -45,6 +45,36 @@ const asMock = {
       removeItem: (...args) => asMock.removeItem(key, ...args),
     };
   }),
+  useAsyncStorageObject: jest.fn((key, defaultValue) => {
+    return {
+      getItem: async (callback) => {
+        try {
+          const value = await asMock.getItem(key);
+          if (value === null) {
+            const result = defaultValue ?? null;
+            callback && callback(null, result);
+            return result;
+          }
+          const parsed = JSON.parse(value);
+          callback && callback(null, parsed);
+          return parsed;
+        } catch (error) {
+          const result = defaultValue ?? null;
+          callback && callback(null, result);
+          return result;
+        }
+      },
+      setItem: async (value, callback) => {
+        const stringified = JSON.stringify(value);
+        return asMock.setItem(key, stringified, callback);
+      },
+      mergeItem: async (value, callback) => {
+        const stringified = JSON.stringify(value);
+        return asMock.mergeItem(key, stringified, callback);
+      },
+      removeItem: (...args) => asMock.removeItem(key, ...args),
+    };
+  }),
 };
 
 async function _multiSet(keyValuePairs, callback) {

--- a/packages/default-storage/package.json
+++ b/packages/default-storage/package.json
@@ -43,7 +43,8 @@
     "build": "bob build",
     "start": "(cd example && react-native start)",
     "test:lint": "eslint $(git ls-files '*.js' '*.ts' '*.tsx')",
-    "test:ts": "tsc"
+    "test:ts": "tsc",
+    "test:unit": "jest"
   },
   "installConfig": {
     "hoistingLimits": "workspaces"
@@ -58,6 +59,7 @@
     "@babel/core": "^7.25.0",
     "@babel/preset-env": "^7.25.0",
     "@react-native/babel-preset": "^0.76.2",
+    "@types/jest": "^29.5.5",
     "@types/lodash": "^4.14.184",
     "@types/mocha": "^10.0.1",
     "@types/react": "^18.0.0",
@@ -72,6 +74,7 @@
     "concurrently": "^8.2.2",
     "eslint": "^8.54.0",
     "expo": "^48.0.0",
+    "jest": "^29.7.0",
     "lodash": "^4.17.21",
     "prettier": "2.8.8",
     "react": "^18.3.1",

--- a/packages/default-storage/src/__tests__/hooks.test.ts
+++ b/packages/default-storage/src/__tests__/hooks.test.ts
@@ -1,0 +1,334 @@
+import AsyncStorage from "../AsyncStorage";
+import { useAsyncStorage, useAsyncStorageObject } from "../hooks";
+
+jest.mock("../AsyncStorage", () => ({
+  __esModule: true,
+  default: {
+    getItem: jest.fn(),
+    setItem: jest.fn(),
+    mergeItem: jest.fn(),
+    removeItem: jest.fn(),
+  },
+}));
+
+const mockedAsyncStorage = AsyncStorage as jest.Mocked<typeof AsyncStorage>;
+
+describe("useAsyncStorage", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns an object with getItem, setItem, mergeItem, and removeItem methods", () => {
+    const hook = useAsyncStorage("testKey");
+
+    expect(hook).toHaveProperty("getItem");
+    expect(hook).toHaveProperty("setItem");
+    expect(hook).toHaveProperty("mergeItem");
+    expect(hook).toHaveProperty("removeItem");
+  });
+
+  it("getItem calls AsyncStorage.getItem with the correct key", async () => {
+    mockedAsyncStorage.getItem.mockResolvedValue("testValue");
+
+    const hook = useAsyncStorage("testKey");
+    const result = await hook.getItem();
+
+    expect(mockedAsyncStorage.getItem).toHaveBeenCalledWith("testKey");
+    expect(result).toBe("testValue");
+  });
+
+  it("setItem calls AsyncStorage.setItem with the correct key and value", async () => {
+    mockedAsyncStorage.setItem.mockResolvedValue(undefined);
+
+    const hook = useAsyncStorage("testKey");
+    await hook.setItem("testValue");
+
+    expect(mockedAsyncStorage.setItem).toHaveBeenCalledWith(
+      "testKey",
+      "testValue"
+    );
+  });
+});
+
+describe("useAsyncStorageObject", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  interface TestUser {
+    name: string;
+    age: number;
+    preferences?: {
+      theme: string;
+      notifications: boolean;
+    };
+  }
+
+  describe("getItem", () => {
+    it("returns parsed object from storage", async () => {
+      const storedUser: TestUser = { name: "John", age: 30 };
+      mockedAsyncStorage.getItem.mockResolvedValue(JSON.stringify(storedUser));
+
+      const hook = useAsyncStorageObject<TestUser>("user");
+      const result = await hook.getItem();
+
+      expect(mockedAsyncStorage.getItem).toHaveBeenCalledWith("user");
+      expect(result).toEqual(storedUser);
+    });
+
+    it("returns null when storage is empty and no default provided", async () => {
+      mockedAsyncStorage.getItem.mockResolvedValue(null);
+
+      const hook = useAsyncStorageObject<TestUser>("user");
+      const result = await hook.getItem();
+
+      expect(result).toBeNull();
+    });
+
+    it("returns defaultValue when storage is empty", async () => {
+      mockedAsyncStorage.getItem.mockResolvedValue(null);
+      const defaultUser: TestUser = { name: "Default", age: 0 };
+
+      const hook = useAsyncStorageObject<TestUser>("user", defaultUser);
+      const result = await hook.getItem();
+
+      expect(result).toEqual(defaultUser);
+    });
+
+    it("returns null on invalid JSON (no default)", async () => {
+      mockedAsyncStorage.getItem.mockResolvedValue("invalid json {{{");
+
+      const hook = useAsyncStorageObject<TestUser>("user");
+      const result = await hook.getItem();
+
+      expect(result).toBeNull();
+    });
+
+    it("returns defaultValue on invalid JSON", async () => {
+      mockedAsyncStorage.getItem.mockResolvedValue("invalid json {{{");
+      const defaultUser: TestUser = { name: "Fallback", age: 25 };
+
+      const hook = useAsyncStorageObject<TestUser>("user", defaultUser);
+      const result = await hook.getItem();
+
+      expect(result).toEqual(defaultUser);
+    });
+
+    it("calls callback with parsed result", async () => {
+      const storedUser: TestUser = { name: "Jane", age: 28 };
+      mockedAsyncStorage.getItem.mockResolvedValue(JSON.stringify(storedUser));
+
+      const callback = jest.fn();
+      const hook = useAsyncStorageObject<TestUser>("user");
+      await hook.getItem(callback);
+
+      expect(callback).toHaveBeenCalledWith(null, storedUser);
+    });
+
+    it("calls callback with null on empty storage", async () => {
+      mockedAsyncStorage.getItem.mockResolvedValue(null);
+
+      const callback = jest.fn();
+      const hook = useAsyncStorageObject<TestUser>("user");
+      await hook.getItem(callback);
+
+      expect(callback).toHaveBeenCalledWith(null, null);
+    });
+
+    it("calls callback with defaultValue on empty storage", async () => {
+      mockedAsyncStorage.getItem.mockResolvedValue(null);
+      const defaultUser: TestUser = { name: "Default", age: 0 };
+
+      const callback = jest.fn();
+      const hook = useAsyncStorageObject<TestUser>("user", defaultUser);
+      await hook.getItem(callback);
+
+      expect(callback).toHaveBeenCalledWith(null, defaultUser);
+    });
+
+    it("handles nested objects correctly", async () => {
+      const complexUser: TestUser = {
+        name: "Alice",
+        age: 35,
+        preferences: {
+          theme: "dark",
+          notifications: true,
+        },
+      };
+      mockedAsyncStorage.getItem.mockResolvedValue(JSON.stringify(complexUser));
+
+      const hook = useAsyncStorageObject<TestUser>("user");
+      const result = await hook.getItem();
+
+      expect(result).toEqual(complexUser);
+      expect(result?.preferences?.theme).toBe("dark");
+    });
+  });
+
+  describe("setItem", () => {
+    it("stores stringified object", async () => {
+      mockedAsyncStorage.setItem.mockResolvedValue(undefined);
+
+      const user: TestUser = { name: "Bob", age: 40 };
+      const hook = useAsyncStorageObject<TestUser>("user");
+      await hook.setItem(user);
+
+      expect(mockedAsyncStorage.setItem).toHaveBeenCalledWith(
+        "user",
+        JSON.stringify(user),
+        undefined
+      );
+    });
+
+    it("stores nested objects correctly", async () => {
+      mockedAsyncStorage.setItem.mockResolvedValue(undefined);
+
+      const user: TestUser = {
+        name: "Carol",
+        age: 25,
+        preferences: {
+          theme: "light",
+          notifications: false,
+        },
+      };
+      const hook = useAsyncStorageObject<TestUser>("user");
+      await hook.setItem(user);
+
+      expect(mockedAsyncStorage.setItem).toHaveBeenCalledWith(
+        "user",
+        JSON.stringify(user),
+        undefined
+      );
+    });
+
+    it("passes callback to AsyncStorage.setItem", async () => {
+      mockedAsyncStorage.setItem.mockResolvedValue(undefined);
+
+      const callback = jest.fn();
+      const user: TestUser = { name: "Dave", age: 50 };
+      const hook = useAsyncStorageObject<TestUser>("user");
+      await hook.setItem(user, callback);
+
+      expect(mockedAsyncStorage.setItem).toHaveBeenCalledWith(
+        "user",
+        JSON.stringify(user),
+        callback
+      );
+    });
+  });
+
+  describe("mergeItem", () => {
+    it("merges partial object with stored object", async () => {
+      mockedAsyncStorage.mergeItem.mockResolvedValue(undefined);
+
+      const partialUpdate: Partial<TestUser> = { age: 31 };
+      const hook = useAsyncStorageObject<TestUser>("user");
+      await hook.mergeItem(partialUpdate);
+
+      expect(mockedAsyncStorage.mergeItem).toHaveBeenCalledWith(
+        "user",
+        JSON.stringify(partialUpdate),
+        undefined
+      );
+    });
+
+    it("merges nested partial objects", async () => {
+      mockedAsyncStorage.mergeItem.mockResolvedValue(undefined);
+
+      const partialUpdate: Partial<TestUser> = {
+        preferences: {
+          theme: "dark",
+          notifications: true,
+        },
+      };
+      const hook = useAsyncStorageObject<TestUser>("user");
+      await hook.mergeItem(partialUpdate);
+
+      expect(mockedAsyncStorage.mergeItem).toHaveBeenCalledWith(
+        "user",
+        JSON.stringify(partialUpdate),
+        undefined
+      );
+    });
+
+    it("passes callback to AsyncStorage.mergeItem", async () => {
+      mockedAsyncStorage.mergeItem.mockResolvedValue(undefined);
+
+      const callback = jest.fn();
+      const partialUpdate: Partial<TestUser> = { name: "Updated" };
+      const hook = useAsyncStorageObject<TestUser>("user");
+      await hook.mergeItem(partialUpdate, callback);
+
+      expect(mockedAsyncStorage.mergeItem).toHaveBeenCalledWith(
+        "user",
+        JSON.stringify(partialUpdate),
+        callback
+      );
+    });
+  });
+
+  describe("removeItem", () => {
+    it("calls AsyncStorage.removeItem with the correct key", async () => {
+      mockedAsyncStorage.removeItem.mockResolvedValue(undefined);
+
+      const hook = useAsyncStorageObject<TestUser>("user");
+      await hook.removeItem();
+
+      expect(mockedAsyncStorage.removeItem).toHaveBeenCalledWith("user");
+    });
+
+    it("passes callback to AsyncStorage.removeItem", async () => {
+      mockedAsyncStorage.removeItem.mockResolvedValue(undefined);
+
+      const callback = jest.fn();
+      const hook = useAsyncStorageObject<TestUser>("user");
+      await hook.removeItem(callback);
+
+      expect(mockedAsyncStorage.removeItem).toHaveBeenCalledWith(
+        "user",
+        callback
+      );
+    });
+  });
+
+  describe("TypeScript type safety", () => {
+    it("maintains type safety for getItem return value", async () => {
+      const storedUser: TestUser = { name: "TypeSafe", age: 42 };
+      mockedAsyncStorage.getItem.mockResolvedValue(JSON.stringify(storedUser));
+
+      const hook = useAsyncStorageObject<TestUser>("user");
+      const result = await hook.getItem();
+
+      // TypeScript should know result is TestUser | null
+      if (result) {
+        expect(result.name).toBe("TypeSafe");
+        expect(result.age).toBe(42);
+      }
+    });
+
+    it("works with arrays", async () => {
+      const storedArray = [1, 2, 3, 4, 5];
+      mockedAsyncStorage.getItem.mockResolvedValue(JSON.stringify(storedArray));
+
+      const hook = useAsyncStorageObject<number[]>("numbers");
+      const result = await hook.getItem();
+
+      expect(result).toEqual([1, 2, 3, 4, 5]);
+    });
+
+    it("works with primitive types wrapped in object", async () => {
+      interface Counter {
+        value: number;
+      }
+      const storedCounter: Counter = { value: 10 };
+      mockedAsyncStorage.getItem.mockResolvedValue(
+        JSON.stringify(storedCounter)
+      );
+
+      const hook = useAsyncStorageObject<Counter>("counter");
+      const result = await hook.getItem();
+
+      expect(result?.value).toBe(10);
+    });
+  });
+});

--- a/packages/default-storage/src/hooks.ts
+++ b/packages/default-storage/src/hooks.ts
@@ -1,11 +1,55 @@
 import AsyncStorage from "./AsyncStorage";
-import type { AsyncStorageHook } from "./types";
+import type {
+  AsyncStorageHook,
+  AsyncStorageObjectHook,
+  Callback,
+  CallbackWithResult,
+} from "./types";
 
 export function useAsyncStorage(key: string): AsyncStorageHook {
   return {
     getItem: (...args) => AsyncStorage.getItem(key, ...args),
     setItem: (...args) => AsyncStorage.setItem(key, ...args),
     mergeItem: (...args) => AsyncStorage.mergeItem(key, ...args),
+    removeItem: (...args) => AsyncStorage.removeItem(key, ...args),
+  };
+}
+
+export function useAsyncStorageObject<T>(
+  key: string,
+  defaultValue?: T
+): AsyncStorageObjectHook<T> {
+  return {
+    getItem: async (
+      callback?: CallbackWithResult<T>
+    ): Promise<T | null> => {
+      try {
+        const value = await AsyncStorage.getItem(key);
+        if (value === null) {
+          const result = defaultValue ?? null;
+          callback?.(null, result);
+          return result;
+        }
+        const parsed = JSON.parse(value) as T;
+        callback?.(null, parsed);
+        return parsed;
+      } catch (error) {
+        const result = defaultValue ?? null;
+        callback?.(null, result);
+        return result;
+      }
+    },
+    setItem: async (value: T, callback?: Callback): Promise<void> => {
+      const stringified = JSON.stringify(value);
+      await AsyncStorage.setItem(key, stringified, callback);
+    },
+    mergeItem: async (
+      value: Partial<T>,
+      callback?: Callback
+    ): Promise<void> => {
+      const stringified = JSON.stringify(value);
+      await AsyncStorage.mergeItem(key, stringified, callback);
+    },
     removeItem: (...args) => AsyncStorage.removeItem(key, ...args),
   };
 }

--- a/packages/default-storage/src/index.ts
+++ b/packages/default-storage/src/index.ts
@@ -1,7 +1,7 @@
 import AsyncStorage from "./AsyncStorage";
 
-export { useAsyncStorage } from "./hooks";
+export { useAsyncStorage, useAsyncStorageObject } from "./hooks";
 
-export type { AsyncStorageStatic } from "./types";
+export type { AsyncStorageStatic, AsyncStorageObjectHook } from "./types";
 
 export default AsyncStorage;

--- a/packages/default-storage/src/types.ts
+++ b/packages/default-storage/src/types.ts
@@ -34,6 +34,13 @@ export type AsyncStorageHook = {
   removeItem: (callback?: Callback) => Promise<void>;
 };
 
+export type AsyncStorageObjectHook<T> = {
+  getItem: (callback?: CallbackWithResult<T>) => Promise<T | null>;
+  setItem: (value: T, callback?: Callback) => Promise<void>;
+  mergeItem: (value: Partial<T>, callback?: Callback) => Promise<void>;
+  removeItem: (callback?: Callback) => Promise<void>;
+};
+
 /**
  * `AsyncStorage` is a simple, unencrypted, asynchronous, persistent, key-value
  * storage system that is global to the app.  It should be used instead of

--- a/packages/default-storage/tsconfig.json
+++ b/packages/default-storage/tsconfig.json
@@ -10,5 +10,6 @@
       "node"
     ]
   },
-  "include": ["example/**/*.ts", "example/**/*.tsx", "src"]
+  "include": ["example/**/*.ts", "example/**/*.tsx", "src"],
+  "exclude": ["src/__tests__"]
 }

--- a/packages/website/docs/API.md
+++ b/packages/website/docs/API.md
@@ -580,3 +580,114 @@ In this example:
 1. On mount, we read the value at `@storage_key` and save it to the state under `value`
 2. When pressing on "update value", a new string gets generated, saved to async storage, and to the component state
 3. Try to reload your app - you'll see that the last value is still being read from async storage
+
+
+## `useAsyncStorageObject`
+
+A hook with automatic JSON serialization for storing and retrieving objects directly, without manual `JSON.stringify()` and `JSON.parse()` calls.
+
+The `useAsyncStorageObject` hook accepts a storage key and an optional default value. It returns an object with methods to interact with the stored value, automatically handling JSON serialization and deserialization.
+
+**Signature**:
+
+```ts
+function useAsyncStorageObject<T>(
+  key: string,
+  defaultValue?: T
+): {
+  getItem: (
+    callback?: (error: Error | null, result: T | null) => void
+  ) => Promise<T | null>;
+  setItem: (
+    value: T,
+    callback?: (error: Error | null) => void
+  ) => Promise<void>;
+  mergeItem: (
+    value: Partial<T>,
+    callback?: (error: Error | null) => void
+  ) => Promise<void>;
+  removeItem: (
+    callback?: (error: Error | null) => void
+  ) => Promise<void>;
+}
+```
+
+**Parameters**:
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| key | `string` | Yes | The storage key to use |
+| defaultValue | `T` | No | Value to return when storage is empty or contains invalid JSON |
+
+**Returns**:
+
+An object with the following methods:
+
+- `getItem` - Retrieves and parses the stored JSON value. Returns `defaultValue` (or `null`) if the key doesn't exist or contains invalid JSON.
+- `setItem` - Stringifies and stores the value.
+- `mergeItem` - Deep merges a partial object with the existing stored object.
+- `removeItem` - Removes the stored value.
+
+**Example**:
+
+```tsx
+import React, { useState, useEffect } from 'react';
+import { View, Text, Button } from 'react-native';
+import { useAsyncStorageObject } from '@react-native-async-storage/async-storage';
+
+interface UserPreferences {
+  theme: 'light' | 'dark';
+  notifications: boolean;
+  language: string;
+}
+
+const defaultPreferences: UserPreferences = {
+  theme: 'light',
+  notifications: true,
+  language: 'en',
+};
+
+export default function SettingsScreen() {
+  const [preferences, setPreferences] = useState<UserPreferences>(defaultPreferences);
+  const { getItem, setItem, mergeItem } = useAsyncStorageObject<UserPreferences>(
+    '@user_preferences',
+    defaultPreferences
+  );
+
+  useEffect(() => {
+    loadPreferences();
+  }, []);
+
+  const loadPreferences = async () => {
+    const stored = await getItem();
+    if (stored) {
+      setPreferences(stored);
+    }
+  };
+
+  const toggleTheme = async () => {
+    const newTheme = preferences.theme === 'light' ? 'dark' : 'light';
+    // Update only the theme property using mergeItem
+    await mergeItem({ theme: newTheme });
+    setPreferences(prev => ({ ...prev, theme: newTheme }));
+  };
+
+  const saveAllPreferences = async (newPrefs: UserPreferences) => {
+    await setItem(newPrefs);
+    setPreferences(newPrefs);
+  };
+
+  return (
+    <View style={{ padding: 20 }}>
+      <Text>Current theme: {preferences.theme}</Text>
+      <Text>Notifications: {preferences.notifications ? 'On' : 'Off'}</Text>
+      <Text>Language: {preferences.language}</Text>
+      <Button title="Toggle Theme" onPress={toggleTheme} />
+    </View>
+  );
+}
+```
+
+**Error Handling**:
+
+The hook gracefully handles JSON parse errors by returning the `defaultValue` (or `null` if no default is provided). This ensures your app won't crash if the stored data becomes corrupted.

--- a/yarn.lock
+++ b/yarn.lock
@@ -4102,6 +4102,7 @@ __metadata:
     "@babel/core": "npm:^7.25.0"
     "@babel/preset-env": "npm:^7.25.0"
     "@react-native/babel-preset": "npm:^0.76.2"
+    "@types/jest": "npm:^29.5.5"
     "@types/lodash": "npm:^4.14.184"
     "@types/mocha": "npm:^10.0.1"
     "@types/react": "npm:^18.0.0"
@@ -4116,6 +4117,7 @@ __metadata:
     concurrently: "npm:^8.2.2"
     eslint: "npm:^8.54.0"
     expo: "npm:^48.0.0"
+    jest: "npm:^29.7.0"
     lodash: "npm:^4.17.21"
     merge-options: "npm:^3.0.4"
     prettier: "npm:2.8.8"
@@ -14619,7 +14621,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest@npm:^29.2.1":
+"jest@npm:^29.2.1, jest@npm:^29.7.0":
   version: 29.7.0
   resolution: "jest@npm:29.7.0"
   dependencies:


### PR DESCRIPTION
…lization

Add a new hook that handles JSON.stringify() and JSON.parse() automatically, allowing direct storage and retrieval of objects without manual serialization.

Features:
- TypeScript generics for type-safe objects
- Optional default value parameter
- Graceful error handling (returns default/null on JSON parse errors)
- Support for getItem, setItem, mergeItem, and removeItem

Also includes:
- Unit tests (23 test cases)
- Jest mock implementation
- API documentation

## Summary

<!--
  Thank you for submitting a PR!

  Help us understand more of your work - you can explain what you did, post a
  link to an issue, screenshots etc. Anything helps!
-->

## Test Plan

<!--
    Help us test your work (**REQUIRED**).

    If you changed the code, please provide us with instructions of how we can
    try it out ourselves, so we can confirm it's working. You can also post
    screenshots/gifts.
-->
