### PR TITLE
Add automatic JSON serialization to storage hook - Sonnet 4.5

### DIFF
--- a/packages/default-storage/example/examples/HookObject.tsx
+++ b/packages/default-storage/example/examples/HookObject.tsx
@@ -1,0 +1,317 @@
+// @ts-expect-error cannot find module
+import { useAsyncStorageObject } from "@react-native-async-storage/async-storage";
+import React, { useEffect, useState } from "react";
+import isEqual from "lodash/isEqual";
+import { Platform, ScrollView, StyleSheet, Text, View } from "react-native";
+
+type User = {
+  name: string;
+  age: number;
+  address?: {
+    city: string;
+    zip: string;
+    country?: string;
+  };
+  preferences?: {
+    theme: string;
+    notifications?: string;
+  };
+};
+
+type TestResult = {
+  name: string;
+  passed: boolean;
+  error?: string;
+};
+
+const testProp = (id: string) =>
+  Platform.select({
+    android: {
+      accessible: true,
+      accessibilityLabel: id,
+    },
+    ios: {
+      accessible: false,
+      testID: id,
+    },
+  });
+
+function HookObject(): JSX.Element {
+  const [results, setResults] = useState<TestResult[]>([]);
+
+  useEffect(() => {
+    const runTests = async () => {
+      const testResults: TestResult[] = [];
+
+      // Test 1: Store and retrieve an object
+      try {
+        const hook = useAsyncStorageObject<User>("test_user");
+        const user: User = { name: "Alice", age: 25 };
+        await hook.setItem(user);
+        const retrieved = await hook.getItem();
+
+        if (isEqual(retrieved, user)) {
+          testResults.push({
+            name: "Should store and retrieve object",
+            passed: true,
+          });
+        } else {
+          testResults.push({
+            name: "Should store and retrieve object",
+            passed: false,
+            error: `Expected ${JSON.stringify(user)}, got ${JSON.stringify(
+              retrieved
+            )}`,
+          });
+        }
+        await hook.removeItem();
+      } catch (error) {
+        testResults.push({
+          name: "Should store and retrieve object",
+          passed: false,
+          error: String(error),
+        });
+      }
+
+      // Test 2: Return null for non-existent key
+      try {
+        const hook = useAsyncStorageObject<User>("nonexistent_key");
+        const retrieved = await hook.getItem();
+
+        if (retrieved === null) {
+          testResults.push({
+            name: "Should return null for non-existent key",
+            passed: true,
+          });
+        } else {
+          testResults.push({
+            name: "Should return null for non-existent key",
+            passed: false,
+            error: `Expected null, got ${JSON.stringify(retrieved)}`,
+          });
+        }
+      } catch (error) {
+        testResults.push({
+          name: "Should return null for non-existent key",
+          passed: false,
+          error: String(error),
+        });
+      }
+
+      // Test 3: Deep merge objects
+      try {
+        const hook = useAsyncStorageObject<User>("merge_user");
+        const initialUser: User = {
+          name: "Bob",
+          age: 30,
+          address: { city: "New York", zip: "10001" },
+          preferences: { theme: "dark", notifications: "enabled" },
+        };
+        await hook.setItem(initialUser);
+
+        await hook.mergeItem({
+          age: 31,
+          address: { country: "USA" },
+          preferences: { theme: "light" },
+        });
+
+        const merged = await hook.getItem();
+        const expected: User = {
+          name: "Bob",
+          age: 31,
+          address: { city: "New York", zip: "10001", country: "USA" },
+          preferences: { theme: "light", notifications: "enabled" },
+        };
+
+        if (isEqual(merged, expected)) {
+          testResults.push({
+            name: "Should deep merge objects",
+            passed: true,
+          });
+        } else {
+          testResults.push({
+            name: "Should deep merge objects",
+            passed: false,
+            error: `Expected ${JSON.stringify(expected)}, got ${JSON.stringify(
+              merged
+            )}`,
+          });
+        }
+        await hook.removeItem();
+      } catch (error) {
+        testResults.push({
+          name: "Should deep merge objects",
+          passed: false,
+          error: String(error),
+        });
+      }
+
+      // Test 4: Remove item
+      try {
+        const hook = useAsyncStorageObject<User>("remove_user");
+        await hook.setItem({ name: "Charlie", age: 28 });
+        await hook.removeItem();
+        const retrieved = await hook.getItem();
+
+        if (retrieved === null) {
+          testResults.push({
+            name: "Should remove item",
+            passed: true,
+          });
+        } else {
+          testResults.push({
+            name: "Should remove item",
+            passed: false,
+            error: `Expected null after removal, got ${JSON.stringify(
+              retrieved
+            )}`,
+          });
+        }
+      } catch (error) {
+        testResults.push({
+          name: "Should remove item",
+          passed: false,
+          error: String(error),
+        });
+      }
+
+      // Test 5: Handle arrays (they should be replaced, not merged)
+      try {
+        const hook = useAsyncStorageObject<{ tags: string[] }>("array_test");
+        await hook.setItem({ tags: ["tag1", "tag2"] });
+        await hook.mergeItem({ tags: ["tag3", "tag4"] });
+        const retrieved = await hook.getItem();
+        const expected = { tags: ["tag3", "tag4"] };
+
+        if (isEqual(retrieved, expected)) {
+          testResults.push({
+            name: "Should replace arrays when merging",
+            passed: true,
+          });
+        } else {
+          testResults.push({
+            name: "Should replace arrays when merging",
+            passed: false,
+            error: `Expected ${JSON.stringify(expected)}, got ${JSON.stringify(
+              retrieved
+            )}`,
+          });
+        }
+        await hook.removeItem();
+      } catch (error) {
+        testResults.push({
+          name: "Should replace arrays when merging",
+          passed: false,
+          error: String(error),
+        });
+      }
+
+      // Test 6: Merge with empty object should keep existing data
+      try {
+        const hook = useAsyncStorageObject<User>("empty_merge_test");
+        const user: User = {
+          name: "David",
+          age: 35,
+          address: { city: "Boston", zip: "02101" },
+        };
+        await hook.setItem(user);
+        await hook.mergeItem({});
+        const retrieved = await hook.getItem();
+
+        if (isEqual(retrieved, user)) {
+          testResults.push({
+            name: "Should keep data when merging empty object",
+            passed: true,
+          });
+        } else {
+          testResults.push({
+            name: "Should keep data when merging empty object",
+            passed: false,
+            error: `Expected ${JSON.stringify(user)}, got ${JSON.stringify(
+              retrieved
+            )}`,
+          });
+        }
+        await hook.removeItem();
+      } catch (error) {
+        testResults.push({
+          name: "Should keep data when merging empty object",
+          passed: false,
+          error: String(error),
+        });
+      }
+
+      setResults(testResults);
+    };
+
+    runTests();
+  }, []);
+
+  return (
+    <ScrollView contentContainerStyle={styles.container}>
+      <View>
+        {results.map((result) => {
+          const testID = "test:" + result.name;
+          if (result.passed) {
+            return (
+              <View key={result.name} style={styles.passed}>
+                <Text style={styles.testLabel}>{result.name}</Text>
+                <Text {...testProp(testID)} style={styles.testResult}>
+                  Pass
+                </Text>
+              </View>
+            );
+          }
+
+          return (
+            <View key={result.name} style={styles.failed}>
+              <Text style={styles.testLabel}>{result.name}</Text>
+              <View>
+                <Text {...testProp(testID)} style={styles.testResult}>
+                  Fail
+                </Text>
+                <Text style={styles.errorText}>{result.error}</Text>
+              </View>
+            </View>
+          );
+        })}
+      </View>
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flexGrow: 1,
+  },
+  errorText: {
+    color: "#ffffff",
+    fontSize: 12,
+  },
+  failed: {
+    backgroundColor: "#e53935",
+    flex: 1,
+    padding: 4,
+  },
+  passed: {
+    flex: 1,
+    flexDirection: "row",
+    padding: 4,
+  },
+  testLabel: {
+    color: "#000000",
+    flex: 1,
+  },
+  testResult: {
+    color: "#000000",
+  },
+});
+
+export default {
+  title: "Hook Object",
+  testId: "hook-object",
+  description: "useAsyncStorageObject hook tests",
+  render() {
+    return <HookObject />;
+  },
+};

--- a/packages/default-storage/example/examples/tests.ts
+++ b/packages/default-storage/example/examples/tests.ts
@@ -1,4 +1,4 @@
-export type TestValue = string | Record<string, string>;
+export type TestValue = string | Record<string, any>;
 
 export type TestStep =
   | {
@@ -70,6 +70,50 @@ const tests: Record<string, TestStep[]> = {
         age: "21",
         eyesColor: "blue",
         shoeSize: "9",
+      },
+    },
+  ],
+  "Should merge nested objects deeply": [
+    {
+      command: "set",
+      key: "deep_merge_test",
+      value: {
+        name: "John",
+        age: "30",
+        address: {
+          city: "New York",
+          zip: "10001",
+        },
+        preferences: {
+          theme: "dark",
+          notifications: "enabled",
+        },
+      },
+    },
+    {
+      command: "merge",
+      key: "deep_merge_test",
+      value: {
+        age: "31",
+        address: {
+          country: "USA",
+        },
+        preferences: {
+          theme: "light",
+        },
+      },
+      expected: {
+        name: "John",
+        age: "31",
+        address: {
+          city: "New York",
+          zip: "10001",
+          country: "USA",
+        },
+        preferences: {
+          theme: "light",
+          notifications: "enabled",
+        },
       },
     },
   ],

--- a/packages/default-storage/jest/async-storage-mock.d.ts
+++ b/packages/default-storage/jest/async-storage-mock.d.ts
@@ -1,9 +1,11 @@
 import type {
   AsyncStorageHook,
+  AsyncStorageObjectHook,
   AsyncStorageStatic,
 } from "../lib/typescript/types";
 
 export function useAsyncStorage(key: string): AsyncStorageHook;
+export function useAsyncStorageObject<T>(key: string): AsyncStorageObjectHook<T>;
 
 declare const AsyncStorage: AsyncStorageStatic;
 export default AsyncStorage;

--- a/packages/default-storage/jest/async-storage-mock.js
+++ b/packages/default-storage/jest/async-storage-mock.js
@@ -45,7 +45,81 @@ const asMock = {
       removeItem: (...args) => asMock.removeItem(key, ...args),
     };
   }),
+  useAsyncStorageObject: jest.fn((key) => {
+    return {
+      getItem: async () => {
+        const item = await asMock.getItem(key);
+        if (item === null) {
+          return null;
+        }
+        try {
+          return JSON.parse(item);
+        } catch (error) {
+          console.warn(
+            `Failed to parse JSON for key "${key}":`,
+            error instanceof Error ? error.message : error
+          );
+          return null;
+        }
+      },
+      setItem: async (value) => {
+        const stringValue = JSON.stringify(value);
+        await asMock.setItem(key, stringValue);
+      },
+      mergeItem: async (value) => {
+        const existingItem = await asMock.getItem(key);
+        let existingObject;
+
+        if (existingItem === null) {
+          existingObject = value;
+        } else {
+          try {
+            existingObject = JSON.parse(existingItem);
+          } catch (parseError) {
+            console.warn(
+              `Failed to parse existing JSON for key "${key}", replacing with new value:`,
+              parseError instanceof Error ? parseError.message : parseError
+            );
+            existingObject = value;
+          }
+        }
+
+        const merged = deepMerge(existingObject, value);
+        const stringValue = JSON.stringify(merged);
+        await asMock.setItem(key, stringValue);
+      },
+      removeItem: async () => {
+        await asMock.removeItem(key);
+      },
+    };
+  }),
 };
+
+function deepMerge(target, source) {
+  const output = { ...target };
+
+  for (const key in source) {
+    if (Object.prototype.hasOwnProperty.call(source, key)) {
+      const sourceValue = source[key];
+      const targetValue = output[key];
+
+      if (
+        sourceValue &&
+        typeof sourceValue === "object" &&
+        !Array.isArray(sourceValue) &&
+        targetValue &&
+        typeof targetValue === "object" &&
+        !Array.isArray(targetValue)
+      ) {
+        output[key] = deepMerge(targetValue, sourceValue);
+      } else {
+        output[key] = sourceValue;
+      }
+    }
+  }
+
+  return output;
+}
 
 async function _multiSet(keyValuePairs, callback) {
   keyValuePairs.forEach((keyValue) => {

--- a/packages/default-storage/src/hooks.ts
+++ b/packages/default-storage/src/hooks.ts
@@ -1,5 +1,39 @@
 import AsyncStorage from "./AsyncStorage";
-import type { AsyncStorageHook } from "./types";
+import type { AsyncStorageHook, AsyncStorageObjectHook } from "./types";
+
+/**
+ * Deep merges two objects. Arrays are replaced, not merged.
+ * @param target The target object
+ * @param source The source object to merge into target
+ * @returns A new merged object
+ */
+function deepMerge<T>(target: T, source: Partial<T>): T {
+  const output = { ...target };
+
+  for (const key in source) {
+    if (Object.prototype.hasOwnProperty.call(source, key)) {
+      const sourceValue = source[key];
+      const targetValue = output[key];
+
+      if (
+        sourceValue &&
+        typeof sourceValue === "object" &&
+        !Array.isArray(sourceValue) &&
+        targetValue &&
+        typeof targetValue === "object" &&
+        !Array.isArray(targetValue)
+      ) {
+        // Both are objects (not arrays), merge recursively
+        output[key] = deepMerge(targetValue, sourceValue);
+      } else {
+        // Otherwise, replace the value
+        output[key] = sourceValue as T[Extract<keyof T, string>];
+      }
+    }
+  }
+
+  return output;
+}
 
 export function useAsyncStorage(key: string): AsyncStorageHook {
   return {
@@ -7,5 +41,66 @@ export function useAsyncStorage(key: string): AsyncStorageHook {
     setItem: (...args) => AsyncStorage.setItem(key, ...args),
     mergeItem: (...args) => AsyncStorage.mergeItem(key, ...args),
     removeItem: (...args) => AsyncStorage.removeItem(key, ...args),
+  };
+}
+
+export function useAsyncStorageObject<T>(
+  key: string
+): AsyncStorageObjectHook<T> {
+  return {
+    getItem: async (): Promise<T | null> => {
+      try {
+        const item = await AsyncStorage.getItem(key);
+        if (item === null) {
+          return null;
+        }
+        return JSON.parse(item) as T;
+      } catch (error) {
+        console.warn(
+          `Failed to parse JSON for key "${key}":`,
+          error instanceof Error ? error.message : error
+        );
+        return null;
+      }
+    },
+
+    setItem: async (value: T): Promise<void> => {
+      const stringValue = JSON.stringify(value);
+      await AsyncStorage.setItem(key, stringValue);
+    },
+
+    mergeItem: async (value: Partial<T>): Promise<void> => {
+      try {
+        const existingItem = await AsyncStorage.getItem(key);
+        let existingObject: T;
+
+        if (existingItem === null) {
+          // If no existing item, treat the partial value as the full object
+          existingObject = value as T;
+        } else {
+          try {
+            existingObject = JSON.parse(existingItem) as T;
+          } catch (parseError) {
+            console.warn(
+              `Failed to parse existing JSON for key "${key}", replacing with new value:`,
+              parseError instanceof Error ? parseError.message : parseError
+            );
+            // If parse fails, treat the new value as the full object
+            existingObject = value as T;
+          }
+        }
+
+        const merged = deepMerge(existingObject, value);
+        const stringValue = JSON.stringify(merged);
+        await AsyncStorage.setItem(key, stringValue);
+      } catch (error) {
+        // Re-throw any storage errors
+        throw error;
+      }
+    },
+
+    removeItem: async (): Promise<void> => {
+      await AsyncStorage.removeItem(key);
+    },
   };
 }

--- a/packages/default-storage/src/index.ts
+++ b/packages/default-storage/src/index.ts
@@ -1,6 +1,6 @@
 import AsyncStorage from "./AsyncStorage";
 
-export { useAsyncStorage } from "./hooks";
+export { useAsyncStorage, useAsyncStorageObject } from "./hooks";
 
 export type { AsyncStorageStatic } from "./types";
 

--- a/packages/default-storage/src/types.ts
+++ b/packages/default-storage/src/types.ts
@@ -34,6 +34,13 @@ export type AsyncStorageHook = {
   removeItem: (callback?: Callback) => Promise<void>;
 };
 
+export type AsyncStorageObjectHook<T> = {
+  getItem: () => Promise<T | null>;
+  setItem: (value: T) => Promise<void>;
+  mergeItem: (value: Partial<T>) => Promise<void>;
+  removeItem: () => Promise<void>;
+};
+
 /**
  * `AsyncStorage` is a simple, unencrypted, asynchronous, persistent, key-value
  * storage system that is global to the app.  It should be used instead of

--- a/packages/website/docs/API.md
+++ b/packages/website/docs/API.md
@@ -580,3 +580,174 @@ In this example:
 1. On mount, we read the value at `@storage_key` and save it to the state under `value`
 2. When pressing on "update value", a new string gets generated, saved to async storage, and to the component state
 3. Try to reload your app - you'll see that the last value is still being read from async storage
+
+
+<br />
+<br />
+
+## `useAsyncStorageObject`
+
+The `useAsyncStorageObject` hook provides automatic JSON serialization for storing and retrieving objects. Unlike `useAsyncStorage` which works with strings only, this hook handles `JSON.stringify()` and `JSON.parse()` automatically, allowing you to work directly with objects.
+
+This hook is fully type-safe when using TypeScript, supporting generics for compile-time type checking of your stored objects.
+
+**Signature**:
+
+```typescript
+function useAsyncStorageObject<T>(key: string): {
+  getItem: () => Promise<T | null>,
+  setItem: (value: T) => Promise<void>,
+  mergeItem: (value: Partial<T>) => Promise<void>,
+  removeItem: () => Promise<void>,
+}
+```
+
+**Returns**:
+
+An object with methods to interact with the stored object value:
+
+- `getItem()`: Retrieves and deserializes the stored object. Returns `null` if the key doesn't exist or if JSON parsing fails (logs warning to console).
+- `setItem(value)`: Serializes and stores the object.
+- `mergeItem(value)`: Deep merges the partial object with the existing stored object. Nested objects are merged recursively, while arrays are replaced (not merged).
+- `removeItem()`: Removes the stored value.
+
+**Error Handling**:
+
+- If stored data is corrupted or not valid JSON, `getItem()` returns `null` and logs a warning to the console.
+- The same behavior applies to `mergeItem()` when existing data cannot be parsed - it treats the new value as the complete object.
+
+**TypeScript Usage**:
+
+```typescript
+import { useAsyncStorageObject } from '@react-native-async-storage/async-storage';
+
+type User = {
+  name: string;
+  age: number;
+  preferences?: {
+    theme: string;
+    notifications: boolean;
+  };
+};
+
+function UserProfile() {
+  const { getItem, setItem, mergeItem } = useAsyncStorageObject<User>('@user_profile');
+
+  // Get typed object
+  const user = await getItem(); // Returns User | null
+
+  // Set object (type-checked)
+  await setItem({
+    name: 'Alice',
+    age: 25,
+    preferences: { theme: 'dark', notifications: true }
+  });
+
+  // Deep merge - only updates specified fields
+  await mergeItem({
+    age: 26,
+    preferences: { theme: 'light' } // notifications remains unchanged
+  });
+}
+```
+
+**JavaScript Example**:
+
+```jsx
+import React, { useState, useEffect } from 'react';
+import { View, Text, TouchableOpacity } from 'react-native';
+import { useAsyncStorageObject } from '@react-native-async-storage/async-storage';
+
+export default function App() {
+  const [user, setUser] = useState(null);
+  const { getItem, setItem, mergeItem } = useAsyncStorageObject('@user_data');
+
+  const readUserFromStorage = async () => {
+    const userData = await getItem();
+    setUser(userData);
+  };
+
+  const saveUser = async () => {
+    const newUser = {
+      name: 'John Doe',
+      age: 30,
+      email: 'john@example.com',
+      preferences: {
+        theme: 'dark',
+        notifications: true,
+      },
+    };
+    await setItem(newUser);
+    setUser(newUser);
+  };
+
+  const updatePreferences = async () => {
+    // Only updates the theme, keeps other user data intact
+    await mergeItem({
+      preferences: {
+        theme: 'light',
+      },
+    });
+    await readUserFromStorage();
+  };
+
+  useEffect(() => {
+    readUserFromStorage();
+  }, []);
+
+  return (
+    <View style={{ margin: 40 }}>
+      <Text>User: {user ? JSON.stringify(user, null, 2) : 'None'}</Text>
+      <TouchableOpacity onPress={saveUser}>
+        <Text>Save User</Text>
+      </TouchableOpacity>
+      <TouchableOpacity onPress={updatePreferences}>
+        <Text>Update Theme</Text>
+      </TouchableOpacity>
+    </View>
+  );
+}
+```
+
+**Deep Merge Behavior**:
+
+The `mergeItem` method performs a deep merge of nested objects:
+
+```js
+// Initial object
+await setItem({
+  name: 'Alice',
+  settings: {
+    theme: 'dark',
+    language: 'en',
+  },
+  tags: ['user', 'premium'],
+});
+
+// Merge with partial object
+await mergeItem({
+  settings: {
+    theme: 'light', // Updates theme
+    // language: 'en' is preserved
+  },
+  tags: ['admin'], // Arrays are replaced, not merged
+});
+
+// Result
+{
+  name: 'Alice',
+  settings: {
+    theme: 'light',
+    language: 'en', // Preserved
+  },
+  tags: ['admin'], // Replaced
+}
+```
+
+**When to Use**:
+
+- ✅ Use `useAsyncStorageObject` when working with structured data (objects)
+- ✅ Use with TypeScript for type-safe storage operations
+- ✅ Use when you need deep merging of nested objects
+- ❌ Use `useAsyncStorage` for simple string values
+- ❌ For very large objects, consider breaking them into smaller keys for better performance


### PR DESCRIPTION
This commit introduces a new hook `useAsyncStorageObject<T>` that provides automatic JSON serialization for storing and retrieving objects. Unlike `useAsyncStorage` which works with strings only, this hook handles JSON.stringify() and JSON.parse() automatically.

Key features:
- Full TypeScript generic support for type-safe object storage
- Promise-only API (no callback support) for modern async/await patterns
- Automatic JSON serialization/deserialization
- Deep merge support for nested objects via mergeItem()
- Graceful error handling - returns null and logs warning on parse errors
- Arrays are replaced (not merged) during merge operations

Changes:
- Added useAsyncStorageObject() function in hooks.ts
- Added AsyncStorageObjectHook<T> type definition
- Implemented deepMerge() helper for recursive object merging
- Updated Jest mocks to support the new hook
- Added comprehensive E2E tests in HookObject.tsx
- Added deep merge test to tests.ts
- Updated API.md with detailed documentation and examples

The hook is fully backward compatible and does not affect existing functionality.

## Summary

<!--
  Thank you for submitting a PR!

  Help us understand more of your work - you can explain what you did, post a
  link to an issue, screenshots etc. Anything helps!
-->

## Test Plan

<!--
    Help us test your work (**REQUIRED**).

    If you changed the code, please provide us with instructions of how we can
    try it out ourselves, so we can confirm it's working. You can also post
    screenshots/gifts.
-->
