### PR TITLE
chore: set up Trusted Publisher

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,7 @@
 name: Release
+permissions:
+  id-token: write
+  contents: read
 on:
   push:
     branches: [main]


### PR DESCRIPTION
## Summary

No need for npm token anymore
