### PR TITLE
chore: remove npm token from gh action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,4 +29,3 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GH_RELEASE_TOKEN }}
           GITHUB_NAME: ${{ vars.GH_BOT_NAME }}
           GITHUB_EMAIL: ${{ vars.GH_BOT_EMAIL }}
-          NPM_TOKEN: ${{ secrets.NPM_RELEASE_TOKEN }}

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -6,7 +6,7 @@ title: FAQ
 
 ## General
 
-### How do I store objects, arrays, or other non-string values?
+### How do I store objects, arrays or other non-string values?
 
 AsyncStorage only stores strings. Serialize values with `JSON.stringify` before writing, and `JSON.parse` when reading:
 


### PR DESCRIPTION
## Summary

So that trusted publishing can finally kick in
