### PR TITLE
chore: bump to node 24 on ci

### DIFF
--- a/.github/actions/setup-project/action.yml
+++ b/.github/actions/setup-project/action.yml
@@ -9,7 +9,7 @@ inputs:
     description: node version to install
     # Use pre-installed Node version in Ubuntu 22.04 runner
     # https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md
-    default: 22.18.0
+    default: 24.13.0
   windows-fix:
     required: false
     description: https://github.com/actions/setup-node/issues/899#issuecomment-1837381044

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,5 +29,5 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GH_RELEASE_TOKEN }}
           GITHUB_NAME: ${{ vars.GH_BOT_NAME }}
           GITHUB_EMAIL: ${{ vars.GH_BOT_EMAIL }}
-          NPM_TOKEN: '' # https://github.com/changesets/changesets/issues/1152#issuecomment-3765490009
+          NPM_TOKEN: "" # https://github.com/changesets/changesets/issues/1152#issuecomment-3765490009
           NPM_CONFIG_PROVENANCE: true


### PR DESCRIPTION
Bump node from 22 to 24 - it ships with npm >= 11.5.1, which is the minimum version that supports OIDC trusted publishing. This avoids needing a separate npm install -g npm@latest step.