### PR TITLE
fix: auto-configure local Maven repo for shared-storage dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,23 +46,6 @@ npm install @react-native-async-storage/async-storage
 yarn add @react-native-async-storage/async-storage
 ```
 
-### Android
-
-Inside your `android/build.gradle(.kts)` file, add link to local maven repo:
-
-```groovy
-allprojects {
-    repositories {
-        // ... others like google(), mavenCentral()
-
-        maven {
-            url = uri(project(":react-native-async-storage_async-storage").file("local_repo"))
-            // or uri("path/to/node_modules/@react-native-async-storage/async-storage/android/local_repo")
-        }
-    }
-}
-```
-
 ### iOS/macOS
 
 Install cocoapods dependencies:

--- a/docs/migration-to-3.md
+++ b/docs/migration-to-3.md
@@ -26,20 +26,7 @@ Other components:
 
 ### Installation changes
 
-Android requires a local Maven repository to be added to your `android/build.gradle(.kts)`:
-
-```groovy
-allprojects {
-    repositories {
-        // ... others like google(), mavenCentral()
-
-        maven {
-            url = uri(project(":react-native-async-storage_async-storage").file("local_repo"))
-            // or uri("path/to/node_modules/@react-native-async-storage/async-storage/android/local_repo")
-        }
-    }
-}
-```
+No additional Android setup is required — the local Maven repository for `shared-storage` is configured automatically by the library's `build.gradle`.
 
 ### `AsyncStorage` is now instance-based
 

--- a/examples/react-native/android/build.gradle
+++ b/examples/react-native/android/build.gradle
@@ -39,8 +39,5 @@ allprojects {
         }()
         mavenCentral()
         google()
-        maven {
-            url = uri(project(":react-native-async-storage_async-storage").file("local_repo"))
-        }
     }
 }

--- a/packages/async-storage/android/build.gradle
+++ b/packages/async-storage/android/build.gradle
@@ -78,8 +78,19 @@ android {
 }
 
 repositories {
+    maven {
+        url("${project.projectDir}/local_repo")
+    }
     mavenCentral()
     google()
+}
+
+rootProject.allprojects {
+    repositories {
+        maven {
+            url("${rootDir}/../node_modules/@react-native-async-storage/async-storage/android/local_repo")
+        }
+    }
 }
 
 dependencies {


### PR DESCRIPTION
## Summary

- Auto-configure the local Maven repository for `shared-storage` in the library's own `build.gradle`
- Remove the manual Android setup step from README, migration guide, and example project

## Problem

The `org.asyncstorage.shared_storage:storage-android:1.0.0` artifact is bundled in `android/local_repo/` but is not published to Maven Central or Google's Maven repository. This means every consumer must manually add the local Maven URL to their root `android/build.gradle`:

```groovy
allprojects {
    repositories {
        maven {
            url = uri(project(":react-native-async-storage_async-storage").file("local_repo"))
        }
    }
}
```

This is easy to miss during installation and causes confusing Gradle build failures (`Could not find org.asyncstorage.shared_storage:storage-android:1.0.0`).

## Fix

Add the local Maven repository configuration directly to the library's `packages/async-storage/android/build.gradle`:

1. **Module-level**: `maven { url("${project.projectDir}/local_repo") }` — resolves the dependency for the module itself
2. **rootProject.allprojects**: `maven { url("${rootDir}/../node_modules/...") }` — ensures transitive resolution across the entire Android build

This makes it work out of the box — no manual setup required.

## Changes

- `packages/async-storage/android/build.gradle` — add local Maven repo configuration
- `README.md` — remove manual Android setup section
- `docs/migration-to-3.md` — remove manual Android setup instructions
- `examples/react-native/android/build.gradle` — remove manual repo config (now inherited)

## Patch (for patch-package users)

Until this is released, you can use this patch with [patch-package](https://github.com/ds300/patch-package):

<details>
<summary>@react-native-async-storage+async-storage+3.0.1.patch</summary>

```diff
diff --git a/node_modules/@react-native-async-storage/async-storage/android/build.gradle b/node_modules/@react-native-async-storage/async-storage/android/build.gradle
index 4f80202..19613fa 100644
--- a/node_modules/@react-native-async-storage/async-storage/android/build.gradle
+++ b/node_modules/@react-native-async-storage/async-storage/android/build.gradle
@@ -78,10 +78,21 @@ android {
 }

 repositories {
+    maven {
+        url("${project.projectDir}/local_repo")
+    }
     mavenCentral()
     google()
 }

+rootProject.allprojects {
+    repositories {
+        maven {
+            url("${rootDir}/../node_modules/@react-native-async-storage/async-storage/android/local_repo")
+        }
+    }
+}
+
 dependencies {
     implementation "com.facebook.react:react-android"
     api "org.asyncstorage.shared_storage:storage-android:1.0.0"
```

</details>
